### PR TITLE
Removes IO.inspect call and improves setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,15 @@ def deps do
 end
 ```
 
+You'll also need to install `pa11y`:
+
+```sh
+npm i pa11y --save-dev --prefix=./assets/
+```
+
 ## Usage
 
-Simply call Excessibility.html_snapshot() and pass it any of:
+To use it `require Excessibility` and then call `Excessibility.html_snapshot/2` and pass it any of:
 
 - a Phoenix Conn
 - a Wallaby Session
@@ -41,6 +47,8 @@ thing
 The module also includes a mix task that you can call to run
 [pa11y](https://github.com/pa11y/pa11y) against the snapshots.
 `MIX_ENV=test mix excessibility`
+
+You may want to add `Excessbility` as an `import` or `require` in your `ConnCase` or `FeatureCase`.
 
 ## Default Configuration
 

--- a/lib/excessibility.ex
+++ b/lib/excessibility.ex
@@ -134,8 +134,6 @@ defmodule Excessibility do
   defp maybe_wrap_html(view_or_element, content) do
     {html, static_path} = call(view_or_element, :html)
 
-    IO.inspect(html)
-
     head =
       case DOM.maybe_one(html, "head") do
         {:ok, head} -> head


### PR DESCRIPTION
Attempted to make a quick pass at adding this to one of my repos, and ran into an issue where the `IO.inspect` was polluting the test suite run output, and doesn't seem necessary for functionality. If you want to keep that, it may make sense to wrap it in a flag.

Also noticed that you need to install `pa11y` and `require` or `import` `Excessibility`, so I added that to the docs.

May close #4 , but I defer that to you.