### PR TITLE
Use import instead of require so html_snapshot is available unqualified

### DIFF
--- a/lib/excessibility.ex
+++ b/lib/excessibility.ex
@@ -42,9 +42,10 @@ defmodule Excessibility do
   """
 
   @doc """
-  Sets up the module for snapshot testing by requiring `Excessibility`.
+  Sets up the module for snapshot testing by importing `Excessibility`.
 
-  This makes the `html_snapshot/2` macro available in your test module.
+  This makes the `html_snapshot/1` and `html_snapshot/2` macros available
+  in your test module without needing to fully qualify them.
 
   ## Example
 
@@ -52,7 +53,7 @@ defmodule Excessibility do
   """
   defmacro __using__(_opts) do
     quote do
-      require Excessibility
+      import Excessibility, only: [html_snapshot: 1, html_snapshot: 2]
     end
   end
 


### PR DESCRIPTION
The documentation shows unqualified usage like `html_snapshot(conn)` but the implementation only did `require`, which still needs full qualification. This changes to `import ... only:` so usage matches the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)