### PR TITLE
Add head_render_path option to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,20 +51,28 @@ mix deps.get
 mix igniter.install excessibility
 ```
 
+**Apps with authentication:** If your app requires login to access most pages, specify a public route for extracting `<head>` content:
+
+```bash
+mix igniter.install excessibility --head-render-path /login
+```
+
 The installer will:
-- Add configuration to `test/test_helper.exs`
+- Add configuration to `config/test.exs`
 - Create a `pa11y.json` with sensible defaults for Phoenix/LiveView
 - Install Pa11y via npm in your assets directory
 
 ## Quick Start
 
-1. **Configure** the endpoint and helper modules in `test/test_helper.exs`. The installer does this automatically, or add manually:
+1. **Configure** the endpoint and helper modules in `config/test.exs`. The installer does this automatically, or add manually:
 
     ```elixir
-    Application.put_env(:excessibility, :endpoint, MyAppWeb.Endpoint)
-    Application.put_env(:excessibility, :system_mod, Excessibility.System)
-    Application.put_env(:excessibility, :browser_mod, Wallaby.Browser)
-    Application.put_env(:excessibility, :live_view_mod, Excessibility.LiveView)
+    config :excessibility,
+      endpoint: MyAppWeb.Endpoint,
+      head_render_path: "/",  # use "/login" for apps with auth
+      system_mod: Excessibility.System,
+      browser_mod: Wallaby.Browser,
+      live_view_mod: Excessibility.LiveView
     ```
 
 2. **Add `use Excessibility`** in tests where you want snapshots:
@@ -233,7 +241,7 @@ Screenshots are saved alongside HTML files with `.png` extension.
 
 | Task | Description |
 |------|-------------|
-| `mix igniter.install excessibility` | Configure test helper, create pa11y.json, install Pa11y via npm |
+| `mix igniter.install excessibility` | Configure config/test.exs, create pa11y.json, install Pa11y via npm |
 | `mix excessibility` | Run Pa11y against all generated snapshots |
 | `mix excessibility.baseline` | Lock current snapshots as baseline |
 | `mix excessibility.compare` | Compare snapshots against baseline, resolve diffs interactively |

--- a/lib/mix/tasks/install.ex
+++ b/lib/mix/tasks/install.ex
@@ -21,11 +21,12 @@ defmodule Mix.Tasks.Excessibility.Install do
       group: :excessibility,
       schema: [
         endpoint: :string,
+        head_render_path: :string,
         assets_dir: :string,
         skip_npm: :boolean
       ],
-      defaults: [skip_npm: false],
-      example: "mix igniter.install excessibility --endpoint MyAppWeb.Endpoint"
+      defaults: [skip_npm: false, head_render_path: "/"],
+      example: "mix igniter.install excessibility --endpoint MyAppWeb.Endpoint --head-render-path /login"
     }
   end
 
@@ -33,14 +34,13 @@ defmodule Mix.Tasks.Excessibility.Install do
   def igniter(igniter) do
     opts = igniter.args.options
 
-    endpoint =
-      fallback_endpoint(opts[:endpoint], igniter)
-
+    endpoint = fallback_endpoint(opts[:endpoint], igniter)
+    head_render_path = opts[:head_render_path] || "/"
     assets_dir = opts[:assets_dir] || default_assets_dir()
     skip_npm? = opts[:skip_npm]
 
     igniter
-    |> ensure_test_config(endpoint)
+    |> ensure_test_config(endpoint, head_render_path)
     |> ensure_pa11y_config()
     |> maybe_install_pa11y(assets_dir, skip_npm?)
   end
@@ -57,9 +57,10 @@ defmodule Mix.Tasks.Excessibility.Install do
 
   defp fallback_endpoint(module, _igniter), do: module
 
-  defp ensure_test_config(igniter, endpoint) do
+  defp ensure_test_config(igniter, endpoint, head_render_path) do
     igniter
     |> Config.configure("test.exs", :excessibility, [:endpoint], endpoint)
+    |> Config.configure("test.exs", :excessibility, [:head_render_path], head_render_path)
     |> Config.configure("test.exs", :excessibility, [:browser_mod], Wallaby.Browser)
     |> Config.configure("test.exs", :excessibility, [:live_view_mod], Excessibility.LiveView)
     |> Config.configure("test.exs", :excessibility, [:system_mod], Excessibility.System)

--- a/test/mix/tasks/excessibility_install_test.exs
+++ b/test/mix/tasks/excessibility_install_test.exs
@@ -16,9 +16,22 @@ defmodule Mix.Tasks.Excessibility.InstallTest do
 
     assert content =~ "config :excessibility"
     assert content =~ "endpoint: DemoWeb.Endpoint"
+    assert content =~ ~s|head_render_path: "/"|
     assert content =~ "browser_mod: Wallaby.Browser"
     assert content =~ "live_view_mod: Excessibility.LiveView"
     assert content =~ "system_mod: Excessibility.System"
+  end
+
+  test "uses custom head_render_path for apps with auth" do
+    igniter =
+      []
+      |> Igniter.Test.test_project()
+      |> put_args(endpoint: "DemoWeb.Endpoint", head_render_path: "/login", skip_npm: true)
+      |> Install.igniter()
+
+    content = file_content(igniter, "config/test.exs")
+
+    assert content =~ ~s|head_render_path: "/login"|
   end
 
   test "does not duplicate configuration" do


### PR DESCRIPTION
Apps with authentication can now specify a public route for extracting <head> content:

    mix igniter.install excessibility --head-render-path /login

Defaults to "/" for apps without auth restrictions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)