### PR TITLE
Add telemetry setup to installer and bump to 0.6.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Excessibility.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/lessthanseventy/excessibility"
-  @version "0.6.0"
+  @version "0.6.1"
 
   def project do
     [


### PR DESCRIPTION
Updated installer to add TelemetryCapture.attach() check to test_helper.exs. This ensures telemetry handlers are attached when EXCESSIBILITY_TELEMETRY_CAPTURE env var is set (which happens automatically when running mix excessibility.debug).

No user action required - the env var is internal to the debug command.