### PR TITLE
feat(enrichers): add Changeset enricher

### DIFF
--- a/lib/telemetry_capture/enrichers/changeset.ex
+++ b/lib/telemetry_capture/enrichers/changeset.ex
@@ -1,0 +1,65 @@
+defmodule Excessibility.TelemetryCapture.Enrichers.Changeset do
+  @moduledoc """
+  Enriches timeline events with Ecto changeset information.
+
+  Detects Ecto.Changeset structs in assigns and extracts:
+  - Validity status
+  - Error count and fields with errors
+  - Changed fields
+
+  Also detects changesets nested in Phoenix.HTML.Form structs.
+
+  ## Output
+
+  Adds to each timeline event:
+  - `changeset_count` - Number of changesets found
+  - `changesets` - List of changeset info maps with:
+    - `key` - The assign key
+    - `valid?` - Whether changeset is valid
+    - `error_count` - Number of errors
+    - `error_fields` - List of fields with errors
+    - `changed_fields` - List of fields that were changed
+  """
+
+  @behaviour Excessibility.TelemetryCapture.Enricher
+
+  @impl true
+  def name, do: :changeset
+
+  @impl true
+  def enrich(assigns, _opts) do
+    changesets = find_changesets(assigns)
+
+    %{
+      changeset_count: length(changesets),
+      changesets: changesets
+    }
+  end
+
+  defp find_changesets(assigns) do
+    assigns
+    |> Enum.flat_map(fn {key, value} ->
+      case extract_changeset(value) do
+        nil -> []
+        changeset -> [build_changeset_info(key, changeset)]
+      end
+    end)
+    |> Enum.sort_by(& &1.key)
+  end
+
+  defp extract_changeset(%Ecto.Changeset{} = changeset), do: changeset
+
+  defp extract_changeset(%Phoenix.HTML.Form{source: %Ecto.Changeset{} = changeset}), do: changeset
+
+  defp extract_changeset(_), do: nil
+
+  defp build_changeset_info(key, changeset) do
+    %{
+      key: key,
+      valid?: changeset.valid?,
+      error_count: length(changeset.errors),
+      error_fields: Enum.map(changeset.errors, fn {field, _} -> field end),
+      changed_fields: Map.keys(changeset.changes)
+    }
+  end
+end

--- a/test/telemetry_capture/enrichers/changeset_test.exs
+++ b/test/telemetry_capture/enrichers/changeset_test.exs
@@ -1,0 +1,100 @@
+defmodule MockSchema do
+  @moduledoc false
+  defstruct [:name, :email, :age]
+end
+
+defmodule Excessibility.TelemetryCapture.Enrichers.ChangesetTest do
+  use ExUnit.Case, async: true
+
+  alias Excessibility.TelemetryCapture.Enrichers.Changeset
+
+  describe "name/0" do
+    test "returns :changeset" do
+      assert Changeset.name() == :changeset
+    end
+  end
+
+  describe "enrich/2" do
+    test "returns empty map when no changesets present" do
+      assigns = %{user: "test", count: 5}
+
+      result = Changeset.enrich(assigns, [])
+
+      assert result == %{changeset_count: 0, changesets: []}
+    end
+
+    test "detects changeset in assigns" do
+      changeset = build_changeset(%{name: "test"}, %{name: "updated"}, true)
+      assigns = %{form_changeset: changeset}
+
+      result = Changeset.enrich(assigns, [])
+
+      assert result.changeset_count == 1
+      assert length(result.changesets) == 1
+
+      [cs_info] = result.changesets
+      assert cs_info.key == :form_changeset
+      assert cs_info.valid? == true
+      assert cs_info.error_count == 0
+    end
+
+    test "detects changeset with errors" do
+      changeset = build_changeset(%{name: "test"}, %{name: ""}, false, name: ["can't be blank"])
+      assigns = %{user_changeset: changeset}
+
+      result = Changeset.enrich(assigns, [])
+
+      assert result.changeset_count == 1
+      [cs_info] = result.changesets
+      assert cs_info.valid? == false
+      assert cs_info.error_count == 1
+      assert cs_info.error_fields == [:name]
+    end
+
+    test "detects multiple changesets" do
+      cs1 = build_changeset(%{}, %{name: "a"}, true)
+      cs2 = build_changeset(%{}, %{email: "b"}, false, email: ["invalid"])
+      assigns = %{user_changeset: cs1, profile_changeset: cs2, other: "value"}
+
+      result = Changeset.enrich(assigns, [])
+
+      assert result.changeset_count == 2
+      assert length(result.changesets) == 2
+    end
+
+    test "extracts changed fields" do
+      # Only name changed, age stayed the same (so not in changes map)
+      changeset = build_changeset(%{name: "old", age: 20}, %{name: "new"}, true)
+      assigns = %{changeset: changeset}
+
+      result = Changeset.enrich(assigns, [])
+
+      [cs_info] = result.changesets
+      assert :name in cs_info.changed_fields
+      refute :age in cs_info.changed_fields
+    end
+
+    test "handles nested changesets in form struct" do
+      changeset = build_changeset(%{name: "test"}, %{name: "updated"}, true)
+      form = %Phoenix.HTML.Form{source: changeset}
+      assigns = %{form: form}
+
+      result = Changeset.enrich(assigns, [])
+
+      assert result.changeset_count == 1
+      [cs_info] = result.changesets
+      assert cs_info.key == :form
+    end
+  end
+
+  # Helper to build a mock changeset-like struct
+  defp build_changeset(data, changes, valid?, errors \\ []) do
+    %Ecto.Changeset{
+      data: struct(MockSchema, data),
+      changes: changes,
+      valid?: valid?,
+      errors: errors,
+      action: if(valid?, do: nil, else: :insert)
+    }
+  end
+end


### PR DESCRIPTION
## Summary

- New enricher that detects Ecto.Changeset structs in assigns
- Extracts changeset metadata for timeline analysis

## What it extracts

- `changeset_count` - Number of changesets found
- `changesets[]` - List with:
  - `key` - The assign key
  - `valid?` - Validity status
  - `error_count` - Number of errors
  - `error_fields` - Fields with errors
  - `changed_fields` - Fields that were modified

Also handles changesets nested in `Phoenix.HTML.Form` structs.

## Test plan

- [x] 7 new tests for Changeset enricher
- [x] All 263 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)