### PR TITLE
feat(enrichers): add BinaryContent enricher

### DIFF
--- a/lib/telemetry_capture/enrichers/binary_content.ex
+++ b/lib/telemetry_capture/enrichers/binary_content.ex
@@ -1,0 +1,93 @@
+defmodule Excessibility.TelemetryCapture.Enrichers.BinaryContent do
+  @moduledoc """
+  Enriches timeline events with information about large binary content.
+
+  Detects large binaries in assigns that could cause memory issues:
+  - Raw binary data (images, files)
+  - Base64 encoded content
+  - Binaries nested in maps and lists
+
+  ## Options
+
+  - `:binary_threshold` - Minimum size in bytes to flag (default: 10_000)
+
+  ## Output
+
+  Adds to each timeline event:
+  - `binary_count` - Number of large binaries found
+  - `total_binary_bytes` - Total size of all large binaries
+  - `large_binaries` - List of binary info maps with:
+    - `key` - The assign key (dot-notation for nested)
+    - `size` - Size in bytes
+  """
+
+  @behaviour Excessibility.TelemetryCapture.Enricher
+
+  @default_threshold 10_000
+
+  @impl true
+  def name, do: :binary_content
+
+  @impl true
+  def enrich(assigns, opts) do
+    threshold = Keyword.get(opts, :binary_threshold, @default_threshold)
+    binaries = find_large_binaries(assigns, threshold, [])
+
+    %{
+      binary_count: length(binaries),
+      total_binary_bytes: Enum.sum(Enum.map(binaries, & &1.size)),
+      large_binaries: binaries
+    }
+  end
+
+  defp find_large_binaries(map, threshold, path) when is_map(map) do
+    Enum.flat_map(map, fn {key, value} ->
+      new_path = path ++ [key]
+      find_large_binaries_in_value(value, threshold, new_path)
+    end)
+  end
+
+  defp find_large_binaries(list, threshold, path) when is_list(list) do
+    list
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {value, idx} ->
+      new_path = path ++ [idx]
+      find_large_binaries_in_value(value, threshold, new_path)
+    end)
+  end
+
+  defp find_large_binaries(_other, _threshold, _path), do: []
+
+  defp find_large_binaries_in_value(value, threshold, path) when is_binary(value) do
+    size = byte_size(value)
+
+    if size >= threshold do
+      [%{key: path_to_key(path), size: size}]
+    else
+      []
+    end
+  end
+
+  defp find_large_binaries_in_value(value, threshold, path) when is_map(value) do
+    # Don't recurse into structs except for specific ones
+    if is_struct(value) do
+      []
+    else
+      find_large_binaries(value, threshold, path)
+    end
+  end
+
+  defp find_large_binaries_in_value(value, threshold, path) when is_list(value) do
+    find_large_binaries(value, threshold, path)
+  end
+
+  defp find_large_binaries_in_value(_value, _threshold, _path), do: []
+
+  defp path_to_key([single]), do: single
+
+  defp path_to_key(path) do
+    path
+    |> Enum.map_join(".", &to_string/1)
+    |> String.to_atom()
+  end
+end

--- a/test/telemetry_capture/enrichers/binary_content_test.exs
+++ b/test/telemetry_capture/enrichers/binary_content_test.exs
@@ -1,0 +1,109 @@
+defmodule Excessibility.TelemetryCapture.Enrichers.BinaryContentTest do
+  use ExUnit.Case, async: true
+
+  alias Excessibility.TelemetryCapture.Enrichers.BinaryContent
+
+  describe "name/0" do
+    test "returns :binary_content" do
+      assert BinaryContent.name() == :binary_content
+    end
+  end
+
+  describe "enrich/2" do
+    test "returns empty stats when no large binaries present" do
+      assigns = %{user: "test", count: 5, small_string: "hello"}
+
+      result = BinaryContent.enrich(assigns, [])
+
+      assert result.binary_count == 0
+      assert result.total_binary_bytes == 0
+      assert result.large_binaries == []
+    end
+
+    test "detects large binary in assigns" do
+      # 50KB binary
+      large_binary = :crypto.strong_rand_bytes(50_000)
+      assigns = %{image_data: large_binary, name: "test"}
+
+      result = BinaryContent.enrich(assigns, [])
+
+      assert result.binary_count == 1
+      assert result.total_binary_bytes == 50_000
+      assert length(result.large_binaries) == 1
+
+      [binary_info] = result.large_binaries
+      assert binary_info.key == :image_data
+      assert binary_info.size == 50_000
+    end
+
+    test "ignores small binaries" do
+      # Small string (under threshold)
+      assigns = %{small: "hello world", medium: String.duplicate("a", 1000)}
+
+      result = BinaryContent.enrich(assigns, [])
+
+      # Default threshold is 10KB, so these should not be flagged
+      assert result.large_binaries == []
+    end
+
+    test "detects multiple large binaries" do
+      bin1 = :crypto.strong_rand_bytes(20_000)
+      bin2 = :crypto.strong_rand_bytes(30_000)
+      assigns = %{file1: bin1, file2: bin2, name: "test"}
+
+      result = BinaryContent.enrich(assigns, [])
+
+      assert result.binary_count == 2
+      assert result.total_binary_bytes == 50_000
+      assert length(result.large_binaries) == 2
+    end
+
+    test "detects base64 encoded content" do
+      # Large base64 string (typical for embedded images)
+      raw = :crypto.strong_rand_bytes(15_000)
+      base64 = Base.encode64(raw)
+      assigns = %{encoded_image: base64}
+
+      result = BinaryContent.enrich(assigns, [])
+
+      # Base64 is ~33% larger than raw
+      assert result.binary_count == 1
+      assert length(result.large_binaries) == 1
+    end
+
+    test "detects binaries nested in maps" do
+      large_binary = :crypto.strong_rand_bytes(25_000)
+      assigns = %{upload: %{data: large_binary, filename: "test.png"}}
+
+      result = BinaryContent.enrich(assigns, [])
+
+      assert result.binary_count == 1
+      [binary_info] = result.large_binaries
+      assert binary_info.key == :"upload.data"
+    end
+
+    test "detects binaries in lists" do
+      bin1 = :crypto.strong_rand_bytes(15_000)
+      bin2 = :crypto.strong_rand_bytes(20_000)
+      assigns = %{files: [%{data: bin1}, %{data: bin2}]}
+
+      result = BinaryContent.enrich(assigns, [])
+
+      assert result.binary_count == 2
+    end
+
+    test "respects custom threshold option" do
+      # 5KB binary
+      binary = :crypto.strong_rand_bytes(5_000)
+      assigns = %{data: binary}
+
+      # Default threshold (10KB) - not flagged
+      result1 = BinaryContent.enrich(assigns, [])
+      assert result1.large_binaries == []
+
+      # Custom threshold (1KB) - flagged
+      result2 = BinaryContent.enrich(assigns, binary_threshold: 1_000)
+      assert length(result2.large_binaries) == 1
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- New enricher that detects large binary content in assigns
- Helps identify memory issues from embedded files/images

## What it detects

- Raw binary data (images, file uploads)
- Base64 encoded content  
- Binaries nested in maps and lists

## Output

- `binary_count` - Number of large binaries found
- `total_binary_bytes` - Total size
- `large_binaries[]` - List with key and size

Configurable threshold via `:binary_threshold` option (default 10KB).

## Test plan

- [x] 9 new tests
- [x] All 265 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)