### PR TITLE
feat: extend MCP server with modular architecture, resources, and prompts

### DIFF
--- a/lib/excessibility/mcp/progress.ex
+++ b/lib/excessibility/mcp/progress.ex
@@ -1,0 +1,102 @@
+defmodule Excessibility.MCP.Progress do
+  @moduledoc """
+  Helper for sending MCP progress notifications.
+
+  Progress notifications allow tools to report their progress during
+  long-running operations.
+
+  ## Usage
+
+      # In a tool's execute function:
+      def execute(args, opts) do
+        callback = Keyword.get(opts, :progress_callback)
+
+        if callback do
+          callback.("Starting...", 0)
+          # ... do work ...
+          callback.("Processing...", 50)
+          # ... more work ...
+          callback.("Complete", 100)
+        end
+
+        {:ok, result}
+      end
+
+      # When calling the tool with progress support:
+      callback = Progress.callback(token: "op-123")
+      Tool.execute(args, progress_callback: callback)
+  """
+
+  @doc """
+  Sends a progress notification to stdout.
+
+  This is used internally by the callback function.
+  """
+  def notify(message, progress, opts \\ []) do
+    token = Keyword.get(opts, :token)
+
+    notification = %{
+      "jsonrpc" => "2.0",
+      "method" => "notifications/progress",
+      "params" => %{
+        "progressToken" => token,
+        "progress" => progress,
+        "total" => 100,
+        "message" => message
+      }
+    }
+
+    json = Jason.encode!(notification)
+    IO.write(:stdio, json <> "\n")
+  end
+
+  @doc """
+  Creates a progress callback function.
+
+  The returned function can be passed to tools via the `:progress_callback` option.
+
+  ## Options
+
+  - `:token` - Progress token for correlating notifications (optional)
+  - `:io` - IO device to write to (default: :stdio)
+
+  ## Example
+
+      callback = Progress.callback(token: "operation-123")
+      callback.("Processing...", 50)
+  """
+  def callback(opts \\ []) do
+    fn message, progress ->
+      notify(message, progress, opts)
+    end
+  end
+
+  @doc """
+  Wraps a function with progress notifications.
+
+  Sends start (0%) and complete (100%) notifications automatically.
+
+  ## Example
+
+      result = Progress.with_progress(
+        "Running analysis",
+        token: "analysis-1",
+        fn ->
+          expensive_operation()
+        end
+      )
+  """
+  def with_progress(description, opts \\ [], fun) do
+    notify("Starting: #{description}", 0, opts)
+
+    try do
+      result = fun.()
+      notify("Complete: #{description}", 100, opts)
+      result
+    rescue
+      e ->
+        notify("Failed: #{description}", 100, opts)
+        reraise e, __STACKTRACE__
+    end
+  end
+end

--- a/lib/excessibility/mcp/prompt.ex
+++ b/lib/excessibility/mcp/prompt.ex
@@ -1,0 +1,93 @@
+defmodule Excessibility.MCP.Prompt do
+  @moduledoc """
+  Behaviour for MCP prompts.
+
+  Prompts are reusable prompt templates that can be retrieved and filled with arguments.
+
+  ## Example
+
+      defmodule MyApp.MCP.Prompts.FixIssue do
+        @behaviour Excessibility.MCP.Prompt
+
+        @impl true
+        def name, do: "fix-issue"
+
+        @impl true
+        def description, do: "Generate a prompt for fixing accessibility issues"
+
+        @impl true
+        def arguments do
+          [
+            %{
+              "name" => "issue",
+              "description" => "The accessibility issue to fix",
+              "required" => true
+            },
+            %{
+              "name" => "element",
+              "description" => "The HTML element causing the issue",
+              "required" => false
+            }
+          ]
+        end
+
+        @impl true
+        def get(args) do
+          issue = Map.get(args, "issue", "unknown issue")
+          element = Map.get(args, "element")
+
+          content = if element do
+            "Fix this accessibility issue: \#{issue}\\n\\nElement: \#{element}"
+          else
+            "Fix this accessibility issue: \#{issue}"
+          end
+
+          {:ok, %{
+            "messages" => [
+              %{
+                "role" => "user",
+                "content" => %{
+                  "type" => "text",
+                  "text" => content
+                }
+              }
+            ]
+          }}
+        end
+      end
+
+  ## Callbacks
+
+  - `name/0` - String identifier for this prompt
+  - `description/0` - Human-readable description
+  - `arguments/0` - List of argument definitions
+  - `get/1` - Returns the prompt content given arguments
+  """
+
+  @callback name() :: String.t()
+  @callback description() :: String.t()
+  @callback arguments() :: [map()]
+  @callback get(args :: map()) :: {:ok, map()} | {:error, String.t()}
+
+  @doc """
+  Returns MCP prompt definition for a prompt module.
+  """
+  def to_mcp_definition(prompt_module) do
+    %{
+      "name" => prompt_module.name(),
+      "description" => prompt_module.description(),
+      "arguments" => prompt_module.arguments()
+    }
+  end
+
+  @doc """
+  Formats a prompt get result for MCP response.
+  """
+  def format_result({:ok, prompt_data}) do
+    prompt_data
+  end
+
+  def format_result({:error, message}) do
+    %{"error" => message}
+  end
+end

--- a/lib/excessibility/mcp/prompts/debug_liveview.ex
+++ b/lib/excessibility/mcp/prompts/debug_liveview.ex
@@ -1,0 +1,122 @@
+defmodule Excessibility.MCP.Prompts.DebugLiveview do
+  @moduledoc """
+  MCP prompt for debugging LiveView state and behavior issues.
+  """
+
+  @behaviour Excessibility.MCP.Prompt
+
+  @impl true
+  def name, do: "debug-liveview"
+
+  @impl true
+  def description, do: "Generate a prompt for debugging LiveView state evolution and behavior issues"
+
+  @impl true
+  def arguments do
+    [
+      %{
+        "name" => "symptom",
+        "description" => "The observed problem (e.g., 'form doesn't update', 'data not loading', 'infinite loop')",
+        "required" => true
+      },
+      %{
+        "name" => "expected",
+        "description" => "What behavior was expected instead",
+        "required" => false
+      },
+      %{
+        "name" => "component",
+        "description" => "The LiveView or LiveComponent name",
+        "required" => false
+      }
+    ]
+  end
+
+  @impl true
+  def get(args) do
+    symptom = Map.get(args, "symptom", "unexpected behavior")
+    expected = Map.get(args, "expected")
+    component = Map.get(args, "component")
+
+    prompt_text = build_prompt(symptom, expected, component)
+
+    {:ok,
+     %{
+       "messages" => [
+         %{
+           "role" => "user",
+           "content" => %{
+             "type" => "text",
+             "text" => prompt_text
+           }
+         }
+       ],
+       "description" => "Use with timeline://latest resource for full context"
+     }}
+  end
+
+  defp build_prompt(symptom, expected, component) do
+    base = """
+    Debug this LiveView issue:
+
+    ## Symptom
+    #{symptom}
+    """
+
+    base =
+      if expected do
+        base <>
+          """
+
+          ## Expected Behavior
+          #{expected}
+          """
+      else
+        base
+      end
+
+    base =
+      if component do
+        base <>
+          """
+
+          ## Component
+          #{component}
+          """
+      else
+        base
+      end
+
+    base <>
+      """
+
+      ## Debugging Steps
+
+      1. **Read the timeline** using `timeline://latest` resource to see:
+         - Event sequence (mount, handle_params, handle_event, render)
+         - State changes at each step
+         - Memory usage patterns
+
+      2. **Look for these common issues:**
+         - Missing or incorrect assigns in mount/0
+         - handle_event not updating socket properly
+         - handle_params not preserving state
+         - Circular event triggers
+         - Memory leaks from growing lists
+
+      3. **Check the timeline for:**
+         - Events that don't change state (no-op handlers)
+         - Rapid event sequences (possible loops)
+         - Memory growth patterns
+         - Missing events you expected to see
+
+      ## Analysis Request
+
+      Please analyze the timeline and:
+      1. Identify the root cause of: #{symptom}
+      2. Show which events/state changes are problematic
+      3. Provide a fix with corrected LiveView code
+      4. Explain how to prevent this issue in the future
+      """
+  end
+end

--- a/lib/excessibility/mcp/prompts/fix_a11y_issue.ex
+++ b/lib/excessibility/mcp/prompts/fix_a11y_issue.ex
@@ -1,0 +1,113 @@
+defmodule Excessibility.MCP.Prompts.FixA11yIssue do
+  @moduledoc """
+  MCP prompt for generating accessibility fix suggestions.
+  """
+
+  @behaviour Excessibility.MCP.Prompt
+
+  @impl true
+  def name, do: "fix-a11y-issue"
+
+  @impl true
+  def description, do: "Generate a prompt for fixing WCAG accessibility violations in Phoenix/LiveView"
+
+  @impl true
+  def arguments do
+    [
+      %{
+        "name" => "issue",
+        "description" =>
+          "The accessibility issue code or description (e.g., 'missing form label', 'WCAG2AA.Principle1.Guideline1_1.1_1_1.H37')",
+        "required" => true
+      },
+      %{
+        "name" => "element",
+        "description" => "The HTML element or code snippet causing the issue",
+        "required" => false
+      },
+      %{
+        "name" => "context",
+        "description" => "Additional context like component name or file path",
+        "required" => false
+      }
+    ]
+  end
+
+  @impl true
+  def get(args) do
+    issue = Map.get(args, "issue", "unknown accessibility issue")
+    element = Map.get(args, "element")
+    context = Map.get(args, "context")
+
+    prompt_text = build_prompt(issue, element, context)
+
+    {:ok,
+     %{
+       "messages" => [
+         %{
+           "role" => "user",
+           "content" => %{
+             "type" => "text",
+             "text" => prompt_text
+           }
+         }
+       ]
+     }}
+  end
+
+  defp build_prompt(issue, element, context) do
+    base = """
+    Fix this accessibility issue in a Phoenix/LiveView application:
+
+    ## Issue
+    #{issue}
+    """
+
+    base =
+      if element do
+        base <>
+          """
+
+          ## Element
+          ```html
+          #{element}
+          ```
+          """
+      else
+        base
+      end
+
+    base =
+      if context do
+        base <>
+          """
+
+          ## Context
+          #{context}
+          """
+      else
+        base
+      end
+
+    base <>
+      """
+
+      ## Requirements
+      - Provide the corrected Phoenix/LiveView code (HEEx template syntax)
+      - Explain why the original code failed WCAG guidelines
+      - Follow Phoenix and LiveView best practices
+      - Use semantic HTML elements where appropriate
+      - Include any necessary ARIA attributes
+
+      ## Common WCAG Fixes Reference
+      - H44: Use `<label>` with `for` attribute matching input `id`
+      - H37: Add `alt` attribute to `<img>` elements
+      - H32: Ensure forms have submit buttons (or use `phx-submit`)
+      - H57: Specify `lang` attribute on `<html>` element
+      - F40: Don't use `meta` refresh/redirect
+      - F65: Missing `title` attribute on iframes
+
+      Please provide the fixed code and explanation.
+      """
+  end
+end

--- a/lib/excessibility/mcp/registry.ex
+++ b/lib/excessibility/mcp/registry.ex
@@ -1,0 +1,204 @@
+defmodule Excessibility.MCP.Registry do
+  @moduledoc """
+  Auto-discovers MCP tools, resources, and prompts at compile time.
+
+  Built-in modules are discovered from:
+  - `lib/excessibility/mcp/tools/` - Tool modules
+  - `lib/excessibility/mcp/resources/` - Resource modules
+  - `lib/excessibility/mcp/prompts/` - Prompt modules
+
+  ## Custom Plugins
+
+  Users can register custom modules via application config:
+
+      # config/test.exs
+      config :excessibility,
+        custom_mcp_tools: [MyApp.MCP.Tools.Custom],
+        custom_mcp_resources: [MyApp.MCP.Resources.Custom],
+        custom_mcp_prompts: [MyApp.MCP.Prompts.Custom]
+
+  Custom modules must implement the appropriate behaviour.
+
+  ## Usage
+
+      # Get all tools (built-in + custom)
+      Registry.discover_tools()
+
+      # Get tool by name
+      Registry.get_tool("e11y_check")
+
+      # Get all resources
+      Registry.discover_resources()
+
+      # Find resource for URI
+      Registry.get_resource_for_uri("snapshot://test.html")
+  """
+
+  @tool_behaviour Excessibility.MCP.Tool
+  @resource_behaviour Excessibility.MCP.Resource
+  @prompt_behaviour Excessibility.MCP.Prompt
+
+  # Compile-time discovery helper functions
+  file_to_module = fn path, subdir ->
+    module_name =
+      path
+      |> Path.basename(".ex")
+      |> Macro.camelize()
+
+    subdir_name = Macro.camelize(subdir)
+    Module.concat([Excessibility.MCP, subdir_name, module_name])
+  end
+
+  implements_behaviour? = fn module, behaviour ->
+    case Code.ensure_compiled(module) do
+      {:module, _} ->
+        behaviours = module.__info__(:attributes)[:behaviour] || []
+        behaviour in behaviours
+
+      {:error, _} ->
+        false
+    end
+  end
+
+  discover_modules = fn subdir, behaviour ->
+    base_path = Path.join([__DIR__, subdir])
+
+    if File.dir?(base_path) do
+      base_path
+      |> Path.join("*.ex")
+      |> Path.wildcard()
+      |> Enum.map(&file_to_module.(&1, subdir))
+      |> Enum.filter(&implements_behaviour?.(&1, behaviour))
+      |> Enum.sort_by(& &1.name())
+    else
+      []
+    end
+  end
+
+  # Built-in plugins discovered at compile time
+  @builtin_tools discover_modules.("tools", @tool_behaviour)
+  @builtin_resources discover_modules.("resources", @resource_behaviour)
+  @builtin_prompts discover_modules.("prompts", @prompt_behaviour)
+
+  @doc """
+  Returns all registered tools (built-in + custom).
+
+  Custom tools can be configured via `:custom_mcp_tools` in app config.
+  """
+  def discover_tools do
+    custom = Application.get_env(:excessibility, :custom_mcp_tools, [])
+    valid_custom = Enum.filter(custom, &valid_tool?/1)
+    merge_plugins(@builtin_tools, valid_custom)
+  end
+
+  @doc """
+  Returns all registered resources (built-in + custom).
+
+  Custom resources can be configured via `:custom_mcp_resources` in app config.
+  """
+  def discover_resources do
+    custom = Application.get_env(:excessibility, :custom_mcp_resources, [])
+    valid_custom = Enum.filter(custom, &valid_resource?/1)
+    merge_plugins(@builtin_resources, valid_custom)
+  end
+
+  @doc """
+  Returns all registered prompts (built-in + custom).
+
+  Custom prompts can be configured via `:custom_mcp_prompts` in app config.
+  """
+  def discover_prompts do
+    custom = Application.get_env(:excessibility, :custom_mcp_prompts, [])
+    valid_custom = Enum.filter(custom, &valid_prompt?/1)
+    merge_plugins(@builtin_prompts, valid_custom)
+  end
+
+  @doc """
+  Finds a tool by name.
+
+  Returns nil if not found.
+  """
+  def get_tool(name) do
+    Enum.find(discover_tools(), fn tool ->
+      tool.name() == name
+    end)
+  end
+
+  @doc """
+  Finds a resource by name.
+
+  Returns nil if not found.
+  """
+  def get_resource(name) do
+    Enum.find(discover_resources(), fn resource ->
+      resource.name() == name
+    end)
+  end
+
+  @doc """
+  Finds a resource that can handle the given URI.
+
+  Returns nil if no matching resource found.
+  """
+  def get_resource_for_uri(uri) do
+    alias Excessibility.MCP.Resource
+
+    Enum.find(discover_resources(), fn resource ->
+      Resource.matches_uri?(resource, uri)
+    end)
+  end
+
+  @doc """
+  Finds a prompt by name.
+
+  Returns nil if not found.
+  """
+  def get_prompt(name) do
+    Enum.find(discover_prompts(), fn prompt ->
+      prompt.name() == name
+    end)
+  end
+
+  # Validates that a module implements the Tool behaviour
+  defp valid_tool?(module) do
+    case Code.ensure_compiled(module) do
+      {:module, _} ->
+        behaviours = module.__info__(:attributes)[:behaviour] || []
+        @tool_behaviour in behaviours
+
+      {:error, _} ->
+        false
+    end
+  end
+
+  # Validates that a module implements the Resource behaviour
+  defp valid_resource?(module) do
+    case Code.ensure_compiled(module) do
+      {:module, _} ->
+        behaviours = module.__info__(:attributes)[:behaviour] || []
+        @resource_behaviour in behaviours
+
+      {:error, _} ->
+        false
+    end
+  end
+
+  # Validates that a module implements the Prompt behaviour
+  defp valid_prompt?(module) do
+    case Code.ensure_compiled(module) do
+      {:module, _} ->
+        behaviours = module.__info__(:attributes)[:behaviour] || []
+        @prompt_behaviour in behaviours
+
+      {:error, _} ->
+        false
+    end
+  end
+
+  # Merges built-in and custom plugins, sorted by name, no duplicates
+  defp merge_plugins(builtin, custom) do
+    (builtin ++ custom)
+    |> Enum.uniq()
+    |> Enum.sort_by(& &1.name())
+  end
+end

--- a/lib/excessibility/mcp/resource.ex
+++ b/lib/excessibility/mcp/resource.ex
@@ -1,0 +1,121 @@
+defmodule Excessibility.MCP.Resource do
+  @moduledoc """
+  Behaviour for MCP resources.
+
+  Resources provide read-only data that can be accessed via URIs.
+
+  ## Example
+
+      defmodule MyApp.MCP.Resources.Config do
+        @behaviour Excessibility.MCP.Resource
+
+        @impl true
+        def uri_pattern, do: "config://{name}"
+
+        @impl true
+        def name, do: "config"
+
+        @impl true
+        def description, do: "Application configuration"
+
+        @impl true
+        def mime_type, do: "application/json"
+
+        @impl true
+        def list do
+          [
+            %{
+              "uri" => "config://app",
+              "name" => "app",
+              "description" => "App config",
+              "mimeType" => "application/json"
+            }
+          ]
+        end
+
+        @impl true
+        def read("config://app") do
+          {:ok, Jason.encode!(%{setting: "value"})}
+        end
+
+        def read(_uri), do: {:error, "Resource not found"}
+      end
+
+  ## Callbacks
+
+  - `uri_pattern/0` - URI template pattern (e.g., "timeline://latest")
+  - `name/0` - Human-readable name for this resource type
+  - `description/0` - Description of what this resource provides
+  - `mime_type/0` - MIME type of the resource content
+  - `list/0` - Returns list of available resource instances
+  - `read/1` - Reads a specific resource by URI
+  """
+
+  @callback uri_pattern() :: String.t()
+  @callback name() :: String.t()
+  @callback description() :: String.t()
+  @callback mime_type() :: String.t()
+  @callback list() :: [map()]
+  @callback read(uri :: String.t()) :: {:ok, String.t()} | {:error, String.t()}
+
+  @doc """
+  Formats a resource read result for MCP response.
+  """
+  def format_result({:ok, content}, uri, mime_type) do
+    %{
+      "contents" => [
+        %{
+          "uri" => uri,
+          "mimeType" => mime_type,
+          "text" => content
+        }
+      ]
+    }
+  end
+
+  def format_result({:error, message}, _uri, _mime_type) do
+    %{
+      "error" => message
+    }
+  end
+
+  @doc """
+  Returns MCP resource definition for a resource module.
+  """
+  def to_mcp_definition(resource_module) do
+    %{
+      "uri" => resource_module.uri_pattern(),
+      "name" => resource_module.name(),
+      "description" => resource_module.description(),
+      "mimeType" => resource_module.mime_type()
+    }
+  end
+
+  @doc """
+  Checks if a URI matches a resource module's pattern.
+
+  Supports simple patterns like:
+  - "timeline://latest" (exact match)
+  - "snapshot://{name}" (matches any snapshot://...)
+  - "config://{type}" (matches any config://...)
+  """
+  def matches_uri?(resource_module, uri) do
+    pattern = resource_module.uri_pattern()
+
+    cond do
+      # Exact match
+      pattern == uri ->
+        true
+
+      # Pattern with placeholder like "snapshot://{name}"
+      String.contains?(pattern, "{") ->
+        # Extract the scheme from both pattern and URI
+        pattern_scheme = pattern |> String.split("://") |> List.first()
+        uri_scheme = uri |> String.split("://") |> List.first()
+        pattern_scheme == uri_scheme
+
+      true ->
+        false
+    end
+  end
+end

--- a/lib/excessibility/mcp/resources/config.ex
+++ b/lib/excessibility/mcp/resources/config.ex
@@ -1,0 +1,82 @@
+defmodule Excessibility.MCP.Resources.Config do
+  @moduledoc """
+  MCP resource for accessing excessibility configuration.
+  """
+
+  @behaviour Excessibility.MCP.Resource
+
+  @impl true
+  def uri_pattern, do: "config://{type}"
+
+  @impl true
+  def name, do: "config"
+
+  @impl true
+  def description, do: "Excessibility and Pa11y configuration"
+
+  @impl true
+  def mime_type, do: "application/json"
+
+  @impl true
+  def list do
+    resources = [
+      %{
+        "uri" => "config://excessibility",
+        "name" => "Excessibility Config",
+        "description" => "Current excessibility application configuration",
+        "mimeType" => "application/json"
+      }
+    ]
+
+    # Add Pa11y config if it exists
+    pa11y_path = get_pa11y_config_path()
+
+    if File.exists?(pa11y_path) do
+      resources ++
+        [
+          %{
+            "uri" => "config://pa11y",
+            "name" => "Pa11y Config",
+            "description" => "Pa11y accessibility checker configuration",
+            "mimeType" => "application/json"
+          }
+        ]
+    else
+      resources
+    end
+  end
+
+  @impl true
+  def read("config://excessibility") do
+    config = %{
+      "excessibility_output_path" =>
+        Application.get_env(:excessibility, :excessibility_output_path, "test/excessibility"),
+      "endpoint" => inspect(Application.get_env(:excessibility, :endpoint)),
+      "pa11y_path" => Application.get_env(:excessibility, :pa11y_path),
+      "pa11y_config" => Application.get_env(:excessibility, :pa11y_config, "pa11y.json"),
+      "head_render_path" => Application.get_env(:excessibility, :head_render_path, "/"),
+      "custom_enrichers" => :excessibility |> Application.get_env(:custom_enrichers, []) |> Enum.map(&inspect/1),
+      "custom_analyzers" => :excessibility |> Application.get_env(:custom_analyzers, []) |> Enum.map(&inspect/1)
+    }
+
+    {:ok, Jason.encode!(config, pretty: true)}
+  end
+
+  def read("config://pa11y") do
+    pa11y_path = get_pa11y_config_path()
+
+    if File.exists?(pa11y_path) do
+      File.read(pa11y_path)
+    else
+      {:error, "Pa11y config not found at #{pa11y_path}"}
+    end
+  end
+
+  def read(uri) do
+    {:error, "Unknown config URI: #{uri}"}
+  end
+
+  defp get_pa11y_config_path do
+    Application.get_env(:excessibility, :pa11y_config, "pa11y.json")
+  end
+end

--- a/lib/excessibility/mcp/resources/snapshot.ex
+++ b/lib/excessibility/mcp/resources/snapshot.ex
@@ -1,0 +1,78 @@
+defmodule Excessibility.MCP.Resources.Snapshot do
+  @moduledoc """
+  MCP resource for accessing HTML snapshots.
+  """
+
+  @behaviour Excessibility.MCP.Resource
+
+  @impl true
+  def uri_pattern, do: "snapshot://{name}"
+
+  @impl true
+  def name, do: "snapshot"
+
+  @impl true
+  def description, do: "HTML snapshots captured during accessibility tests"
+
+  @impl true
+  def mime_type, do: "text/html"
+
+  @impl true
+  def list do
+    snapshots_dir = get_snapshots_dir()
+
+    if File.dir?(snapshots_dir) do
+      snapshots_dir
+      |> Path.join("*.html")
+      |> Path.wildcard()
+      # Filter out diff files
+      |> Enum.reject(&diff_file?/1)
+      |> Enum.map(&snapshot_to_resource/1)
+    else
+      []
+    end
+  end
+
+  @impl true
+  def read("snapshot://" <> name) do
+    snapshots_dir = get_snapshots_dir()
+    path = Path.join(snapshots_dir, name)
+
+    cond do
+      not File.exists?(path) ->
+        {:error, "Snapshot not found: #{name}"}
+
+      String.contains?(name, "..") ->
+        {:error, "Invalid snapshot name"}
+
+      true ->
+        File.read(path)
+    end
+  end
+
+  def read(uri) do
+    {:error, "Invalid snapshot URI: #{uri}"}
+  end
+
+  defp diff_file?(path) do
+    String.contains?(path, ".good.html") or String.contains?(path, ".bad.html")
+  end
+
+  defp get_snapshots_dir do
+    base_path = Application.get_env(:excessibility, :excessibility_output_path, "test/excessibility")
+    Path.join(base_path, "html_snapshots")
+  end
+
+  defp snapshot_to_resource(path) do
+    filename = Path.basename(path)
+    stat = File.stat!(path)
+
+    %{
+      "uri" => "snapshot://#{filename}",
+      "name" => filename,
+      "description" => "HTML snapshot: #{filename}",
+      "mimeType" => "text/html",
+      "size" => stat.size
+    }
+  end
+end

--- a/lib/excessibility/mcp/resources/timeline.ex
+++ b/lib/excessibility/mcp/resources/timeline.ex
@@ -1,0 +1,61 @@
+defmodule Excessibility.MCP.Resources.Timeline do
+  @moduledoc """
+  MCP resource for accessing timeline data.
+  """
+
+  @behaviour Excessibility.MCP.Resource
+
+  @impl true
+  def uri_pattern, do: "timeline://latest"
+
+  @impl true
+  def name, do: "timeline"
+
+  @impl true
+  def description, do: "LiveView timeline showing state evolution at each event"
+
+  @impl true
+  def mime_type, do: "application/json"
+
+  @impl true
+  def list do
+    timeline_path = get_timeline_path()
+
+    if File.exists?(timeline_path) do
+      stat = File.stat!(timeline_path)
+
+      [
+        %{
+          "uri" => "timeline://latest",
+          "name" => "Latest Timeline",
+          "description" => "Most recent timeline capture",
+          "mimeType" => "application/json",
+          "size" => stat.size,
+          "mtime" => DateTime.to_iso8601(stat.mtime |> NaiveDateTime.from_erl!() |> DateTime.from_naive!("Etc/UTC"))
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  @impl true
+  def read("timeline://latest") do
+    timeline_path = get_timeline_path()
+
+    if File.exists?(timeline_path) do
+      File.read(timeline_path)
+    else
+      {:error, "Timeline file not found at #{timeline_path}"}
+    end
+  end
+
+  def read(uri) do
+    {:error, "Unknown timeline URI: #{uri}"}
+  end
+
+  defp get_timeline_path do
+    base_path = Application.get_env(:excessibility, :excessibility_output_path, "test/excessibility")
+    Path.join(base_path, "timeline.json")
+  end
+end

--- a/lib/excessibility/mcp/tool.ex
+++ b/lib/excessibility/mcp/tool.ex
@@ -1,0 +1,90 @@
+defmodule Excessibility.MCP.Tool do
+  @moduledoc """
+  Behaviour for MCP tools.
+
+  Tools are executable actions that can be called via the MCP protocol.
+
+  ## Example
+
+      defmodule MyApp.MCP.Tools.MyTool do
+        @behaviour Excessibility.MCP.Tool
+
+        @impl true
+        def name, do: "my_tool"
+
+        @impl true
+        def description, do: "Does something useful"
+
+        @impl true
+        def input_schema do
+          %{
+            "type" => "object",
+            "properties" => %{
+              "arg1" => %{"type" => "string", "description" => "First argument"}
+            },
+            "required" => ["arg1"]
+          }
+        end
+
+        @impl true
+        def execute(args, _opts) do
+          {:ok, %{"result" => args["arg1"]}}
+        end
+      end
+
+  ## Callbacks
+
+  - `name/0` - Returns string identifier for this tool
+  - `description/0` - Human-readable description of what the tool does
+  - `input_schema/0` - JSON Schema for the tool's input arguments
+  - `execute/2` - Takes args map and opts keyword list, returns result
+
+  ## Options
+
+  The `opts` keyword list may contain:
+  - `:progress_callback` - Function to call with progress updates
+  """
+
+  @callback name() :: String.t()
+  @callback description() :: String.t()
+  @callback input_schema() :: map()
+  @callback execute(args :: map(), opts :: keyword()) ::
+              {:ok, map()} | {:error, String.t()}
+
+  @doc """
+  Formats a successful tool result for MCP response.
+  """
+  def format_result({:ok, data}) do
+    %{
+      "content" => [
+        %{
+          "type" => "text",
+          "text" => Jason.encode!(data)
+        }
+      ]
+    }
+  end
+
+  def format_result({:error, message}) do
+    %{
+      "content" => [
+        %{
+          "type" => "text",
+          "text" => Jason.encode!(%{"error" => message})
+        }
+      ],
+      "isError" => true
+    }
+  end
+
+  @doc """
+  Returns the MCP tool definition for a tool module.
+  """
+  def to_mcp_definition(tool_module) do
+    %{
+      "name" => tool_module.name(),
+      "description" => tool_module.description(),
+      "inputSchema" => tool_module.input_schema()
+    }
+  end
+end

--- a/lib/excessibility/mcp/tools/analyze_timeline.ex
+++ b/lib/excessibility/mcp/tools/analyze_timeline.ex
@@ -1,0 +1,176 @@
+defmodule Excessibility.MCP.Tools.AnalyzeTimeline do
+  @moduledoc """
+  MCP tool for running analyzers on existing timeline data.
+
+  This tool runs analyzers on a previously captured timeline without
+  re-running tests, useful for iterative analysis.
+  """
+
+  @behaviour Excessibility.MCP.Tool
+
+  alias Excessibility.TelemetryCapture.Analyzer
+  alias Excessibility.TelemetryCapture.Registry
+
+  @impl true
+  def name, do: "analyze_timeline"
+
+  @impl true
+  def description do
+    "Run analyzers on existing timeline data without re-running tests. " <>
+      "Available analyzers: memory, performance, data_growth, event_pattern, " <>
+      "n_plus_one, state_machine, render_efficiency, assign_lifecycle, " <>
+      "handle_event_noop, form_validation, summary, cascade_effect, hypothesis, " <>
+      "code_pointer, accessibility_correlation"
+  end
+
+  @impl true
+  def input_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "analyzers" => %{
+          "type" => "string",
+          "description" =>
+            "Comma-separated list of analyzers to run, or 'all' for all analyzers, or 'default' for default analyzers"
+        },
+        "path" => %{
+          "type" => "string",
+          "description" => "Custom path to timeline.json (optional)"
+        },
+        "verbose" => %{
+          "type" => "boolean",
+          "description" => "Show detailed stats even when no issues found"
+        }
+      }
+    }
+  end
+
+  @impl true
+  def execute(args, opts) do
+    progress_callback = Keyword.get(opts, :progress_callback)
+
+    if progress_callback, do: progress_callback.("Loading timeline...", 0)
+
+    base_path = Application.get_env(:excessibility, :excessibility_output_path, "test/excessibility")
+    timeline_path = Map.get(args, "path") || Path.join(base_path, "timeline.json")
+
+    case load_timeline(timeline_path) do
+      {:ok, timeline} ->
+        if progress_callback, do: progress_callback.("Running analyzers...", 20)
+
+        analyzer_names = parse_analyzers(Map.get(args, "analyzers", "default"))
+        verbose? = Map.get(args, "verbose", false)
+
+        results = run_analyzers(timeline, analyzer_names, verbose?: verbose?)
+
+        if progress_callback, do: progress_callback.("Analysis complete", 100)
+
+        {:ok,
+         %{
+           "status" => "success",
+           "timeline_path" => timeline_path,
+           "analyzers_run" => Enum.map(analyzer_names, &to_string/1),
+           "results" => format_results(results)
+         }}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp load_timeline(path) do
+    with true <- File.exists?(path),
+         {:ok, content} <- File.read(path),
+         {:ok, data} <- Jason.decode(content) do
+      {:ok, data}
+    else
+      false -> {:error, "Timeline file not found: #{path}"}
+      {:error, %Jason.DecodeError{}} -> {:error, "Invalid JSON in timeline file"}
+      {:error, reason} -> {:error, "Failed to read timeline: #{inspect(reason)}"}
+    end
+  end
+
+  defp parse_analyzers(nil), do: parse_analyzers("default")
+  defp parse_analyzers(""), do: parse_analyzers("default")
+
+  defp parse_analyzers("all") do
+    Enum.map(Registry.get_all_analyzers(), & &1.name())
+  end
+
+  defp parse_analyzers("default") do
+    Enum.map(Registry.get_default_analyzers(), & &1.name())
+  end
+
+  defp parse_analyzers(names_str) when is_binary(names_str) do
+    names_str
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.map(&String.to_atom/1)
+  end
+
+  defp run_analyzers(timeline, analyzer_names, opts) do
+    analyzers =
+      analyzer_names
+      |> Enum.map(&Registry.get_analyzer/1)
+      |> Enum.reject(&is_nil/1)
+
+    # Sort by dependencies for correct execution order
+    sorted_analyzers = Analyzer.sort_by_dependencies(analyzers)
+
+    # Run analyzers in order, accumulating results for dependent analyzers
+    {results, _} =
+      Enum.reduce(sorted_analyzers, {%{}, %{}}, fn analyzer, {results, prior_results} ->
+        # Pass prior results to analyzer
+        analyzer_opts = Keyword.put(opts, :prior_results, prior_results)
+        result = analyzer.analyze(timeline, analyzer_opts)
+
+        # Accumulate results
+        {
+          Map.put(results, analyzer.name(), result),
+          Map.put(prior_results, analyzer.name(), result)
+        }
+      end)
+
+    results
+  end
+
+  defp format_results(results) do
+    Map.new(results, fn {name, result} -> {to_string(name), format_analyzer_result(result)} end)
+  end
+
+  defp format_analyzer_result(%{findings: findings, stats: stats}) do
+    %{
+      "findings" => Enum.map(findings, &format_finding/1),
+      "stats" => stringify_keys(stats)
+    }
+  end
+
+  defp format_analyzer_result(other), do: other
+
+  defp format_finding(%{severity: severity, message: message} = finding) do
+    base = %{
+      "severity" => to_string(severity),
+      "message" => message
+    }
+
+    base =
+      if Map.has_key?(finding, :events) do
+        Map.put(base, "events", finding.events)
+      else
+        base
+      end
+
+    if Map.has_key?(finding, :metadata) do
+      Map.put(base, "metadata", stringify_keys(finding.metadata))
+    else
+      base
+    end
+  end
+
+  defp stringify_keys(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {to_string(k), stringify_keys(v)} end)
+  end
+
+  defp stringify_keys(list) when is_list(list), do: Enum.map(list, &stringify_keys/1)
+  defp stringify_keys(value), do: value
+end

--- a/lib/excessibility/mcp/tools/e11y_check.ex
+++ b/lib/excessibility/mcp/tools/e11y_check.ex
@@ -1,0 +1,53 @@
+defmodule Excessibility.MCP.Tools.E11yCheck do
+  @moduledoc """
+  MCP tool for running Pa11y accessibility checks on HTML snapshots.
+  """
+
+  @behaviour Excessibility.MCP.Tool
+
+  @impl true
+  def name, do: "e11y_check"
+
+  @impl true
+  def description do
+    "Run Pa11y accessibility checks on HTML snapshots. Without args: check existing snapshots. With test_args: run tests first, then check."
+  end
+
+  @impl true
+  def input_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "test_args" => %{
+          "type" => "string",
+          "description" => "Arguments to pass to mix test (optional)"
+        }
+      }
+    }
+  end
+
+  @impl true
+  def execute(args, opts) do
+    test_args = Map.get(args, "test_args", "")
+    progress_callback = Keyword.get(opts, :progress_callback)
+
+    if progress_callback, do: progress_callback.("Starting Pa11y check...", 0)
+
+    {output, exit_code} =
+      if test_args == "" do
+        System.cmd("mix", ["excessibility"], stderr_to_stdout: true)
+      else
+        cmd_args = String.split(test_args)
+        System.cmd("mix", ["excessibility" | cmd_args], stderr_to_stdout: true)
+      end
+
+    if progress_callback, do: progress_callback.("Pa11y check complete", 100)
+
+    {:ok,
+     %{
+       "status" => if(exit_code == 0, do: "success", else: "failure"),
+       "exit_code" => exit_code,
+       "output" => output
+     }}
+  end
+end

--- a/lib/excessibility/mcp/tools/e11y_debug.ex
+++ b/lib/excessibility/mcp/tools/e11y_debug.ex
@@ -1,0 +1,72 @@
+defmodule Excessibility.MCP.Tools.E11yDebug do
+  @moduledoc """
+  MCP tool for running tests with telemetry capture and timeline analysis.
+  """
+
+  @behaviour Excessibility.MCP.Tool
+
+  @impl true
+  def name, do: "e11y_debug"
+
+  @impl true
+  def description do
+    "Run tests with telemetry capture and timeline analysis for debugging LiveView state."
+  end
+
+  @impl true
+  def input_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "test_args" => %{
+          "type" => "string",
+          "description" => "Arguments to pass to mix test (required)"
+        },
+        "analyzers" => %{
+          "type" => "string",
+          "description" => "Comma-separated list of analyzers to run"
+        }
+      },
+      "required" => ["test_args"]
+    }
+  end
+
+  @impl true
+  def execute(args, opts) do
+    test_args = Map.get(args, "test_args", "")
+    analyzers = Map.get(args, "analyzers")
+    progress_callback = Keyword.get(opts, :progress_callback)
+
+    if progress_callback, do: progress_callback.("Running tests with telemetry capture...", 0)
+
+    cmd_args = String.split(test_args)
+    cmd_args = if analyzers, do: cmd_args ++ ["--analyze=#{analyzers}"], else: cmd_args
+
+    {output, exit_code} =
+      System.cmd("mix", ["excessibility.debug" | cmd_args], stderr_to_stdout: true)
+
+    if progress_callback, do: progress_callback.("Reading timeline...", 80)
+
+    base_path = Application.get_env(:excessibility, :excessibility_output_path, "test/excessibility")
+    timeline_path = Path.join(base_path, "timeline.json")
+
+    timeline =
+      if File.exists?(timeline_path) do
+        case File.read(timeline_path) do
+          {:ok, content} -> Jason.decode!(content)
+          _ -> nil
+        end
+      end
+
+    if progress_callback, do: progress_callback.("Debug complete", 100)
+
+    {:ok,
+     %{
+       "status" => if(exit_code == 0, do: "success", else: "failure"),
+       "exit_code" => exit_code,
+       "output" => output,
+       "timeline_path" => timeline_path,
+       "timeline" => timeline
+     }}
+  end
+end

--- a/lib/excessibility/mcp/tools/get_snapshots.ex
+++ b/lib/excessibility/mcp/tools/get_snapshots.ex
@@ -1,0 +1,84 @@
+defmodule Excessibility.MCP.Tools.GetSnapshots do
+  @moduledoc """
+  MCP tool for listing or reading HTML snapshots.
+  """
+
+  @behaviour Excessibility.MCP.Tool
+
+  @impl true
+  def name, do: "get_snapshots"
+
+  @impl true
+  def description do
+    "List or read HTML snapshots captured during tests."
+  end
+
+  @impl true
+  def input_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "filter" => %{
+          "type" => "string",
+          "description" => "Glob pattern to filter snapshots (e.g., '*_test_*.html')"
+        },
+        "include_content" => %{
+          "type" => "boolean",
+          "description" => "Include HTML content in response"
+        }
+      }
+    }
+  end
+
+  @impl true
+  def execute(args, _opts) do
+    base_path = Application.get_env(:excessibility, :excessibility_output_path, "test/excessibility")
+    snapshots_dir = Path.join(base_path, "html_snapshots")
+    filter = Map.get(args, "filter", "*.html")
+    include_content? = Map.get(args, "include_content", false)
+
+    result =
+      if File.dir?(snapshots_dir) do
+        pattern = Path.join(snapshots_dir, filter)
+
+        snapshots =
+          pattern
+          |> Path.wildcard()
+          # Filter out diff files
+          |> Enum.reject(&diff_file?/1)
+          |> Enum.map(&build_snapshot(&1, include_content?))
+
+        %{
+          "status" => "success",
+          "count" => length(snapshots),
+          "snapshots" => snapshots
+        }
+      else
+        %{
+          "status" => "not_found",
+          "error" => "Snapshots directory not found",
+          "path" => snapshots_dir
+        }
+      end
+
+    {:ok, result}
+  end
+
+  defp diff_file?(path) do
+    String.contains?(path, ".good.html") or String.contains?(path, ".bad.html")
+  end
+
+  defp build_snapshot(path, include_content?) do
+    snapshot = %{
+      "filename" => Path.basename(path),
+      "path" => path,
+      "size" => File.stat!(path).size
+    }
+
+    if include_content? do
+      Map.put(snapshot, "content", File.read!(path))
+    else
+      snapshot
+    end
+  end
+end

--- a/lib/excessibility/mcp/tools/get_timeline.ex
+++ b/lib/excessibility/mcp/tools/get_timeline.ex
@@ -1,0 +1,61 @@
+defmodule Excessibility.MCP.Tools.GetTimeline do
+  @moduledoc """
+  MCP tool for reading captured timeline data.
+  """
+
+  @behaviour Excessibility.MCP.Tool
+
+  @impl true
+  def name, do: "get_timeline"
+
+  @impl true
+  def description do
+    "Read the captured timeline showing LiveView state evolution at each event."
+  end
+
+  @impl true
+  def input_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "path" => %{
+          "type" => "string",
+          "description" => "Custom path to timeline.json (optional)"
+        }
+      }
+    }
+  end
+
+  @impl true
+  def execute(args, _opts) do
+    base_path = Application.get_env(:excessibility, :excessibility_output_path, "test/excessibility")
+    timeline_path = Map.get(args, "path") || Path.join(base_path, "timeline.json")
+
+    result =
+      if File.exists?(timeline_path) do
+        case File.read(timeline_path) do
+          {:ok, content} ->
+            %{
+              "status" => "success",
+              "path" => timeline_path,
+              "timeline" => Jason.decode!(content)
+            }
+
+          {:error, reason} ->
+            %{
+              "status" => "error",
+              "error" => "Failed to read file: #{inspect(reason)}",
+              "path" => timeline_path
+            }
+        end
+      else
+        %{
+          "status" => "not_found",
+          "error" => "Timeline file not found",
+          "path" => timeline_path
+        }
+      end
+
+    {:ok, result}
+  end
+end

--- a/lib/excessibility/mcp/tools/suggest_fixes.ex
+++ b/lib/excessibility/mcp/tools/suggest_fixes.ex
@@ -1,0 +1,312 @@
+defmodule Excessibility.MCP.Tools.SuggestFixes do
+  @moduledoc """
+  MCP tool for parsing Pa11y output and suggesting Phoenix-specific fixes.
+  """
+
+  @behaviour Excessibility.MCP.Tool
+
+  @impl true
+  def name, do: "suggest_fixes"
+
+  @impl true
+  def description do
+    "Parse Pa11y accessibility violations and suggest Phoenix/LiveView fixes. " <>
+      "Provides code examples for common WCAG issues."
+  end
+
+  @impl true
+  def input_schema do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "pa11y_output" => %{
+          "type" => "string",
+          "description" => "Raw Pa11y output or JSON results to parse"
+        },
+        "run_pa11y" => %{
+          "type" => "boolean",
+          "description" => "Run Pa11y first and analyze the results (default: false)"
+        }
+      }
+    }
+  end
+
+  @impl true
+  def execute(args, opts) do
+    progress_callback = Keyword.get(opts, :progress_callback)
+    run_pa11y? = Map.get(args, "run_pa11y", false)
+
+    pa11y_output =
+      if run_pa11y? do
+        if progress_callback, do: progress_callback.("Running Pa11y...", 0)
+        {output, _exit_code} = System.cmd("mix", ["excessibility"], stderr_to_stdout: true)
+        output
+      else
+        Map.get(args, "pa11y_output", "")
+      end
+
+    if progress_callback, do: progress_callback.("Parsing issues...", 50)
+
+    issues = parse_pa11y_output(pa11y_output)
+    suggestions = Enum.map(issues, &suggest_fix/1)
+
+    if progress_callback, do: progress_callback.("Complete", 100)
+
+    {:ok,
+     %{
+       "status" => "success",
+       "issues_found" => length(issues),
+       "suggestions" => suggestions
+     }}
+  end
+
+  # ============================================================================
+  # Parsing
+  # ============================================================================
+
+  defp parse_pa11y_output(output) when is_binary(output) do
+    case Jason.decode(output) do
+      {:ok, data} when is_list(data) ->
+        Enum.map(data, &parse_json_issue/1)
+
+      {:ok, %{"issues" => issues}} when is_list(issues) ->
+        Enum.map(issues, &parse_json_issue/1)
+
+      _ ->
+        parse_text_output(output)
+    end
+  end
+
+  defp parse_json_issue(%{"code" => code, "message" => message} = issue) do
+    %{
+      code: code,
+      message: message,
+      selector: Map.get(issue, "selector"),
+      context: Map.get(issue, "context"),
+      type: Map.get(issue, "type", "error")
+    }
+  end
+
+  defp parse_json_issue(issue) when is_map(issue) do
+    %{
+      code: Map.get(issue, "code") || Map.get(issue, "rule"),
+      message: Map.get(issue, "message") || Map.get(issue, "description"),
+      selector: Map.get(issue, "selector"),
+      context: Map.get(issue, "context") || Map.get(issue, "html"),
+      type: Map.get(issue, "type", "error")
+    }
+  end
+
+  defp parse_text_output(output) do
+    output
+    |> String.split("\n")
+    |> Enum.filter(&String.contains?(&1, ["Error:", "Warning:", "Notice:"]))
+    |> Enum.map(&parse_text_line/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp parse_text_line(line) do
+    cond do
+      String.contains?(line, "Error:") -> build_text_issue(line, "error")
+      String.contains?(line, "Warning:") -> build_text_issue(line, "warning")
+      true -> nil
+    end
+  end
+
+  defp build_text_issue(line, type) do
+    %{type: type, code: extract_code(line), message: extract_message(line), selector: nil, context: nil}
+  end
+
+  defp extract_code(line) do
+    case Regex.run(~r/\b(WCAG\d+[A-Z]{1,2}\.[^:]+|[A-Z]\d+)\b/, line) do
+      [_, code] -> code
+      _ -> "unknown"
+    end
+  end
+
+  defp extract_message(line) do
+    line
+    |> String.replace(~r/^(Error|Warning|Notice):\s*/, "")
+    |> String.trim()
+  end
+
+  # ============================================================================
+  # Fix Suggestions
+  # ============================================================================
+
+  defp suggest_fix(%{code: code, message: message} = issue) do
+    suggestion = get_fix_suggestion(code, message)
+
+    %{
+      "issue" => %{
+        "code" => code,
+        "message" => message,
+        "type" => Map.get(issue, :type),
+        "selector" => Map.get(issue, :selector),
+        "context" => Map.get(issue, :context)
+      },
+      "suggestion" => suggestion
+    }
+  end
+
+  defp get_fix_suggestion(code, message) do
+    rule = identify_rule(code || "", message || "")
+    fix_for_rule(rule, code, message)
+  end
+
+  defp identify_rule(code, message) do
+    Enum.find_value(rule_matchers(), :unknown, fn {rule, matcher} -> if matcher.(code, message), do: rule end)
+  end
+
+  # Rule matchers - each returns true if the rule applies
+  defp rule_matchers do
+    [
+      {:h44, &matches_h44?/2},
+      {:h37, &matches_h37?/2},
+      {:h32, &matches_h32?/2},
+      {:h57, &matches_h57?/2},
+      {:f65, &matches_f65?/2},
+      {:contrast, &matches_contrast?/2}
+    ]
+  end
+
+  defp matches_h44?(code, message), do: String.contains?(code, "H44") or String.contains?(message, "label")
+
+  defp matches_h37?(code, message),
+    do: String.contains?(code, "H37") or (String.contains?(message, "img") and String.contains?(message, "alt"))
+
+  defp matches_h32?(code, message), do: String.contains?(code, "H32") or String.contains?(message, "submit")
+  defp matches_h57?(code, message), do: String.contains?(code, "H57") or String.contains?(message, "lang")
+  defp matches_f65?(code, message), do: String.contains?(code, "F65") or String.contains?(message, "iframe")
+  defp matches_contrast?(_code, message), do: String.contains?(message, "contrast")
+
+  defp fix_for_rule(:h44, _code, _message), do: fix_h44()
+  defp fix_for_rule(:h37, _code, _message), do: fix_h37()
+  defp fix_for_rule(:h32, _code, _message), do: fix_h32()
+  defp fix_for_rule(:h57, _code, _message), do: fix_h57()
+  defp fix_for_rule(:f65, _code, _message), do: fix_f65()
+  defp fix_for_rule(:contrast, _code, _message), do: fix_contrast()
+  defp fix_for_rule(:unknown, code, message), do: fix_unknown(code, message)
+
+  defp fix_h44 do
+    %{
+      "rule" => "H44",
+      "description" => "Form inputs must have associated labels",
+      "phoenix_fix" => """
+      <!-- Bad: input without label -->
+      <input type="text" name="user[name]" id="user_name" />
+
+      <!-- Good: label with for attribute -->
+      <label for="user_name">Name</label>
+      <input type="text" name="user[name]" id="user_name" />
+
+      <!-- Or using Phoenix form helpers -->
+      <.input field={@form[:name]} type="text" label="Name" />
+      """,
+      "wcag" => "WCAG 2.1 Level A - 1.3.1 Info and Relationships"
+    }
+  end
+
+  defp fix_h37 do
+    %{
+      "rule" => "H37",
+      "description" => "Images must have alt attributes",
+      "phoenix_fix" => """
+      <!-- Bad: image without alt -->
+      <img src={@avatar_url} />
+
+      <!-- Good: descriptive alt text -->
+      <img src={@avatar_url} alt={"Profile photo of \#{@user.name}"} />
+
+      <!-- For decorative images, use empty alt -->
+      <img src="/decorative-border.png" alt="" />
+      """,
+      "wcag" => "WCAG 2.1 Level A - 1.1.1 Non-text Content"
+    }
+  end
+
+  defp fix_h32 do
+    %{
+      "rule" => "H32",
+      "description" => "Forms must have submit buttons",
+      "phoenix_fix" => """
+      <!-- LiveView forms with phx-submit are valid -->
+      <form phx-submit="save">
+        <!-- inputs -->
+        <button type="submit">Save</button>
+      </form>
+
+      <!-- If Pa11y still flags this, add to pa11y.json ignore list:
+      {
+        "ignore": ["WCAG2AA.Principle1.Guideline1_3.1_3_1.H32.2"]
+      }
+      -->
+      """,
+      "wcag" => "WCAG 2.1 Level A - 1.3.1 Info and Relationships"
+    }
+  end
+
+  defp fix_h57 do
+    %{
+      "rule" => "H57",
+      "description" => "HTML element must have lang attribute",
+      "phoenix_fix" => """
+      <!-- In root.html.heex -->
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>...</head>
+        <body>...</body>
+      </html>
+
+      <!-- For dynamic language -->
+      <html lang={@locale}>
+      """,
+      "wcag" => "WCAG 2.1 Level A - 3.1.1 Language of Page"
+    }
+  end
+
+  defp fix_f65 do
+    %{
+      "rule" => "F65",
+      "description" => "Iframes must have title attributes",
+      "phoenix_fix" => """
+      <!-- Bad -->
+      <iframe src={@embed_url}></iframe>
+
+      <!-- Good -->
+      <iframe src={@embed_url} title="Embedded video player"></iframe>
+      """,
+      "wcag" => "WCAG 2.1 Level A - 2.4.1 Bypass Blocks"
+    }
+  end
+
+  defp fix_contrast do
+    %{
+      "rule" => "Color Contrast",
+      "description" => "Text must have sufficient contrast with background",
+      "phoenix_fix" => """
+      /* Ensure 4.5:1 ratio for normal text, 3:1 for large text */
+
+      /* Bad: low contrast */
+      .text-gray { color: #999; background: #fff; }
+
+      /* Good: sufficient contrast */
+      .text-gray { color: #595959; background: #fff; }
+
+      /* Use tools like WebAIM Contrast Checker */
+      """,
+      "wcag" => "WCAG 2.1 Level AA - 1.4.3 Contrast (Minimum)"
+    }
+  end
+
+  defp fix_unknown(code, message) do
+    %{
+      "rule" => code || "unknown",
+      "description" => message,
+      "phoenix_fix" =>
+        "Review the WCAG guidelines for this specific issue. " <>
+          "Check https://www.w3.org/WAI/WCAG21/quickref/ for detailed guidance.",
+      "wcag" => "See WCAG 2.1 guidelines"
+    }
+  end
+end

--- a/test/mcp/registry_test.exs
+++ b/test/mcp/registry_test.exs
@@ -1,0 +1,147 @@
+defmodule Excessibility.MCP.RegistryTest do
+  use ExUnit.Case, async: true
+
+  alias Excessibility.MCP.Registry
+
+  describe "discover_tools/0" do
+    test "discovers built-in tools" do
+      tools = Registry.discover_tools()
+
+      assert is_list(tools)
+      assert length(tools) >= 6
+
+      tool_names = Enum.map(tools, & &1.name())
+      assert "e11y_check" in tool_names
+      assert "e11y_debug" in tool_names
+      assert "get_timeline" in tool_names
+      assert "get_snapshots" in tool_names
+      assert "analyze_timeline" in tool_names
+      assert "suggest_fixes" in tool_names
+    end
+
+    test "tools implement Tool behaviour" do
+      tools = Registry.discover_tools()
+
+      for tool <- tools do
+        assert is_binary(tool.name())
+        assert is_binary(tool.description())
+        assert is_map(tool.input_schema())
+      end
+    end
+  end
+
+  describe "get_tool/1" do
+    test "finds tool by name" do
+      tool = Registry.get_tool("e11y_check")
+
+      assert tool
+      assert tool.name() == "e11y_check"
+    end
+
+    test "returns nil for unknown tool" do
+      assert Registry.get_tool("nonexistent") == nil
+    end
+  end
+
+  describe "discover_resources/0" do
+    test "discovers built-in resources" do
+      resources = Registry.discover_resources()
+
+      assert is_list(resources)
+      assert length(resources) >= 3
+
+      resource_names = Enum.map(resources, & &1.name())
+      assert "config" in resource_names
+      assert "snapshot" in resource_names
+      assert "timeline" in resource_names
+    end
+
+    test "resources implement Resource behaviour" do
+      resources = Registry.discover_resources()
+
+      for resource <- resources do
+        assert is_binary(resource.uri_pattern())
+        assert is_binary(resource.name())
+        assert is_binary(resource.description())
+        assert is_binary(resource.mime_type())
+        assert is_list(resource.list())
+      end
+    end
+  end
+
+  describe "get_resource/1" do
+    test "finds resource by name" do
+      resource = Registry.get_resource("config")
+
+      assert resource
+      assert resource.name() == "config"
+    end
+
+    test "returns nil for unknown resource" do
+      assert Registry.get_resource("nonexistent") == nil
+    end
+  end
+
+  describe "get_resource_for_uri/1" do
+    test "finds resource for exact URI match" do
+      resource = Registry.get_resource_for_uri("timeline://latest")
+
+      assert resource
+      assert resource.name() == "timeline"
+    end
+
+    test "finds resource for pattern URI match" do
+      resource = Registry.get_resource_for_uri("snapshot://test.html")
+
+      assert resource
+      assert resource.name() == "snapshot"
+    end
+
+    test "finds config resource" do
+      resource = Registry.get_resource_for_uri("config://excessibility")
+
+      assert resource
+      assert resource.name() == "config"
+    end
+
+    test "returns nil for unknown URI" do
+      assert Registry.get_resource_for_uri("unknown://something") == nil
+    end
+  end
+
+  describe "discover_prompts/0" do
+    test "discovers built-in prompts" do
+      prompts = Registry.discover_prompts()
+
+      assert is_list(prompts)
+      assert length(prompts) >= 2
+
+      prompt_names = Enum.map(prompts, & &1.name())
+      assert "fix-a11y-issue" in prompt_names
+      assert "debug-liveview" in prompt_names
+    end
+
+    test "prompts implement Prompt behaviour" do
+      prompts = Registry.discover_prompts()
+
+      for prompt <- prompts do
+        assert is_binary(prompt.name())
+        assert is_binary(prompt.description())
+        assert is_list(prompt.arguments())
+      end
+    end
+  end
+
+  describe "get_prompt/1" do
+    test "finds prompt by name" do
+      prompt = Registry.get_prompt("fix-a11y-issue")
+
+      assert prompt
+      assert prompt.name() == "fix-a11y-issue"
+    end
+
+    test "returns nil for unknown prompt" do
+      assert Registry.get_prompt("nonexistent") == nil
+    end
+  end
+end

--- a/test/mcp/server_test.exs
+++ b/test/mcp/server_test.exs
@@ -3,22 +3,383 @@ defmodule Excessibility.MCP.ServerTest do
 
   alias Excessibility.MCP.Server
 
-  # The custom MCP server uses private message handlers,
-  # so we test it by simulating JSON-RPC messages
+  # ============================================================================
+  # Setup
+  # ============================================================================
+
+  setup do
+    # Start a fresh server for each test
+    {:ok, pid} = GenServer.start_link(Server, [], [])
+    {:ok, server: pid}
+  end
+
+  # ============================================================================
+  # Public API Tests
+  # ============================================================================
 
   describe "start/0" do
     test "function exists" do
-      # Ensure module is loaded first
       {:module, _} = Code.ensure_loaded(Server)
       assert {:start, 0} in Server.__info__(:functions)
     end
   end
 
-  describe "module attributes" do
-    test "defines expected tools" do
-      # Verify the module is loaded and has the expected structure
-      assert Code.ensure_loaded?(Server)
-      assert {:module, Excessibility.MCP.Server} = Code.ensure_compiled(Server)
+  describe "start_link/1" do
+    test "starts server as GenServer" do
+      assert {:ok, pid} = Server.start_link([])
+      assert Process.alive?(pid)
+      GenServer.stop(pid)
+    end
+  end
+
+  # ============================================================================
+  # Initialize Tests
+  # ============================================================================
+
+  describe "initialize" do
+    test "returns protocol info and capabilities", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "initialize",
+        "params" => %{
+          "protocolVersion" => "2024-11-05",
+          "clientInfo" => %{"name" => "test"}
+        }
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["jsonrpc"] == "2.0"
+      assert response["id"] == 1
+      assert response["result"]["protocolVersion"] == "2024-11-05"
+      assert response["result"]["serverInfo"]["name"] == "excessibility"
+      assert response["result"]["capabilities"]["tools"] == %{}
+      assert response["result"]["capabilities"]["resources"]["subscribe"] == false
+      assert response["result"]["capabilities"]["prompts"]["listChanged"] == false
+    end
+  end
+
+  # ============================================================================
+  # Tools Tests
+  # ============================================================================
+
+  describe "tools/list" do
+    test "returns list of available tools", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "tools/list"
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["jsonrpc"] == "2.0"
+      assert response["id"] == 1
+
+      tools = response["result"]["tools"]
+      assert is_list(tools)
+
+      # Check for expected tools
+      tool_names = Enum.map(tools, & &1["name"])
+      assert "e11y_check" in tool_names
+      assert "e11y_debug" in tool_names
+      assert "get_timeline" in tool_names
+      assert "get_snapshots" in tool_names
+      assert "analyze_timeline" in tool_names
+      assert "suggest_fixes" in tool_names
+
+      # Verify tool structure
+      e11y_check = Enum.find(tools, &(&1["name"] == "e11y_check"))
+      assert e11y_check["description"]
+      assert e11y_check["inputSchema"]["type"] == "object"
+    end
+  end
+
+  describe "tools/call" do
+    test "calls get_timeline tool", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "get_timeline",
+          "arguments" => %{}
+        }
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["jsonrpc"] == "2.0"
+      assert response["id"] == 1
+      assert response["result"]["content"]
+
+      content = hd(response["result"]["content"])
+      assert content["type"] == "text"
+      result = Jason.decode!(content["text"])
+      # File might not exist, but we should get a valid response structure
+      assert result["status"] in ["success", "not_found"]
+    end
+
+    test "calls get_snapshots tool", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "get_snapshots",
+          "arguments" => %{}
+        }
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["jsonrpc"] == "2.0"
+      content = hd(response["result"]["content"])
+      result = Jason.decode!(content["text"])
+      assert result["status"] in ["success", "not_found"]
+    end
+
+    test "returns error for unknown tool", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "nonexistent_tool",
+          "arguments" => %{}
+        }
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["result"]["isError"] == true
+      content = hd(response["result"]["content"])
+      result = Jason.decode!(content["text"])
+      assert result["error"] =~ "Unknown tool"
+    end
+  end
+
+  # ============================================================================
+  # Resources Tests
+  # ============================================================================
+
+  describe "resources/list" do
+    test "returns list of available resources", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "resources/list"
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["jsonrpc"] == "2.0"
+      assert response["id"] == 1
+
+      resources = response["result"]["resources"]
+      assert is_list(resources)
+
+      # Should always have at least the excessibility config
+      resource_uris =
+        Enum.map(resources, & &1["uri"])
+
+      assert "config://excessibility" in resource_uris
+    end
+  end
+
+  describe "resources/read" do
+    test "reads excessibility config", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "resources/read",
+        "params" => %{
+          "uri" => "config://excessibility"
+        }
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["jsonrpc"] == "2.0"
+      assert response["id"] == 1
+
+      contents = response["result"]["contents"]
+      assert is_list(contents)
+      assert length(contents) == 1
+
+      content = hd(contents)
+      assert content["uri"] == "config://excessibility"
+      assert content["mimeType"] == "application/json"
+
+      config = Jason.decode!(content["text"])
+      assert Map.has_key?(config, "excessibility_output_path")
+    end
+
+    test "returns error for unknown resource", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "resources/read",
+        "params" => %{
+          "uri" => "unknown://resource"
+        }
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["result"]["error"] =~ "Resource not found"
+    end
+  end
+
+  # ============================================================================
+  # Prompts Tests
+  # ============================================================================
+
+  describe "prompts/list" do
+    test "returns list of available prompts", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "prompts/list"
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["jsonrpc"] == "2.0"
+      assert response["id"] == 1
+
+      prompts = response["result"]["prompts"]
+      assert is_list(prompts)
+
+      prompt_names = Enum.map(prompts, & &1["name"])
+      assert "fix-a11y-issue" in prompt_names
+      assert "debug-liveview" in prompt_names
+
+      # Verify prompt structure
+      fix_prompt = Enum.find(prompts, &(&1["name"] == "fix-a11y-issue"))
+      assert fix_prompt["description"]
+      assert is_list(fix_prompt["arguments"])
+    end
+  end
+
+  describe "prompts/get" do
+    test "gets fix-a11y-issue prompt", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "prompts/get",
+        "params" => %{
+          "name" => "fix-a11y-issue",
+          "arguments" => %{
+            "issue" => "Missing form label",
+            "element" => "<input type='text' />"
+          }
+        }
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["jsonrpc"] == "2.0"
+      assert response["id"] == 1
+
+      messages = response["result"]["messages"]
+      assert is_list(messages)
+      assert length(messages) == 1
+
+      user_message = hd(messages)
+      assert user_message["role"] == "user"
+      assert user_message["content"]["type"] == "text"
+      assert user_message["content"]["text"] =~ "Missing form label"
+      assert user_message["content"]["text"] =~ "<input type='text' />"
+    end
+
+    test "gets debug-liveview prompt", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "prompts/get",
+        "params" => %{
+          "name" => "debug-liveview",
+          "arguments" => %{
+            "symptom" => "Form doesn't update",
+            "expected" => "Form should show validation errors"
+          }
+        }
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["result"]["messages"]
+      message_text = hd(response["result"]["messages"])["content"]["text"]
+      assert message_text =~ "Form doesn't update"
+      assert message_text =~ "Form should show validation errors"
+    end
+
+    test "returns error for unknown prompt", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "prompts/get",
+        "params" => %{
+          "name" => "nonexistent-prompt",
+          "arguments" => %{}
+        }
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["result"]["error"] =~ "Prompt not found"
+    end
+  end
+
+  # ============================================================================
+  # Ping & Error Handling Tests
+  # ============================================================================
+
+  describe "ping" do
+    test "responds to ping", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "ping"
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["jsonrpc"] == "2.0"
+      assert response["id"] == 1
+      assert response["result"] == %{}
+    end
+  end
+
+  describe "unknown method" do
+    test "returns method not found error", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "unknown/method"
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response["jsonrpc"] == "2.0"
+      assert response["id"] == 1
+      assert response["error"]["code"] == -32_601
+      assert response["error"]["message"] =~ "Method not found"
+    end
+  end
+
+  describe "notifications" do
+    test "returns nil for initialized notification", %{server: pid} do
+      message = %{
+        "jsonrpc" => "2.0",
+        "method" => "notifications/initialized"
+      }
+
+      response = Server.handle_rpc(pid, message)
+
+      assert response == nil
     end
   end
 end

--- a/test/mcp/tools/suggest_fixes_test.exs
+++ b/test/mcp/tools/suggest_fixes_test.exs
@@ -1,0 +1,169 @@
+defmodule Excessibility.MCP.Tools.SuggestFixesTest do
+  use ExUnit.Case, async: true
+
+  alias Excessibility.MCP.Tools.SuggestFixes
+
+  describe "name/0" do
+    test "returns tool name" do
+      assert SuggestFixes.name() == "suggest_fixes"
+    end
+  end
+
+  describe "input_schema/0" do
+    test "returns valid schema" do
+      schema = SuggestFixes.input_schema()
+
+      assert schema["type"] == "object"
+      assert Map.has_key?(schema["properties"], "pa11y_output")
+      assert Map.has_key?(schema["properties"], "run_pa11y")
+    end
+  end
+
+  describe "execute/2 with JSON input" do
+    test "parses JSON issue array" do
+      pa11y_output =
+        Jason.encode!([
+          %{
+            "code" => "WCAG2AA.Principle1.Guideline1_1.1_1_1.H37",
+            "message" => "Img element missing an alt attribute",
+            "selector" => "img.avatar",
+            "context" => "<img src=\"avatar.png\" class=\"avatar\">"
+          }
+        ])
+
+      {:ok, result} = SuggestFixes.execute(%{"pa11y_output" => pa11y_output}, [])
+
+      assert result["status"] == "success"
+      assert result["issues_found"] == 1
+
+      [suggestion] = result["suggestions"]
+      assert suggestion["issue"]["code"] == "WCAG2AA.Principle1.Guideline1_1.1_1_1.H37"
+      assert suggestion["suggestion"]["rule"] == "H37"
+      assert suggestion["suggestion"]["phoenix_fix"] =~ "alt"
+    end
+
+    test "parses JSON with issues key" do
+      pa11y_output =
+        Jason.encode!(%{
+          "issues" => [
+            %{
+              "code" => "H44",
+              "message" => "Form input missing label"
+            }
+          ]
+        })
+
+      {:ok, result} = SuggestFixes.execute(%{"pa11y_output" => pa11y_output}, [])
+
+      assert result["issues_found"] == 1
+      [suggestion] = result["suggestions"]
+      assert suggestion["suggestion"]["rule"] == "H44"
+      assert suggestion["suggestion"]["phoenix_fix"] =~ "label"
+    end
+  end
+
+  describe "execute/2 with text input" do
+    test "parses text output with Error:" do
+      pa11y_output = """
+      Error: WCAG2AA.Principle1.Guideline1_1.1_1_1.H37 - Img element missing an alt attribute
+      Warning: WCAG2AA.Principle1.Guideline1_3.1_3_1.H44 - Form input missing label
+      """
+
+      {:ok, result} = SuggestFixes.execute(%{"pa11y_output" => pa11y_output}, [])
+
+      assert result["status"] == "success"
+      assert result["issues_found"] == 2
+    end
+  end
+
+  describe "execute/2 fix suggestions" do
+    test "suggests fix for H37 (alt text)" do
+      pa11y_output = Jason.encode!([%{"code" => "H37", "message" => "Missing alt"}])
+
+      {:ok, result} = SuggestFixes.execute(%{"pa11y_output" => pa11y_output}, [])
+
+      [suggestion] = result["suggestions"]
+      assert suggestion["suggestion"]["rule"] == "H37"
+      assert suggestion["suggestion"]["phoenix_fix"] =~ "alt="
+      assert suggestion["suggestion"]["wcag"] =~ "1.1.1"
+    end
+
+    test "suggests fix for H44 (form labels)" do
+      pa11y_output = Jason.encode!([%{"code" => "H44", "message" => "Missing label"}])
+
+      {:ok, result} = SuggestFixes.execute(%{"pa11y_output" => pa11y_output}, [])
+
+      [suggestion] = result["suggestions"]
+      assert suggestion["suggestion"]["rule"] == "H44"
+      assert suggestion["suggestion"]["phoenix_fix"] =~ "<label"
+      assert suggestion["suggestion"]["phoenix_fix"] =~ ".input"
+    end
+
+    test "suggests fix for H32 (submit buttons)" do
+      pa11y_output = Jason.encode!([%{"code" => "H32", "message" => "No submit button"}])
+
+      {:ok, result} = SuggestFixes.execute(%{"pa11y_output" => pa11y_output}, [])
+
+      [suggestion] = result["suggestions"]
+      assert suggestion["suggestion"]["rule"] == "H32"
+      assert suggestion["suggestion"]["phoenix_fix"] =~ "phx-submit"
+    end
+
+    test "suggests fix for H57 (language attribute)" do
+      pa11y_output = Jason.encode!([%{"code" => "H57", "message" => "Missing lang"}])
+
+      {:ok, result} = SuggestFixes.execute(%{"pa11y_output" => pa11y_output}, [])
+
+      [suggestion] = result["suggestions"]
+      assert suggestion["suggestion"]["rule"] == "H57"
+      assert suggestion["suggestion"]["phoenix_fix"] =~ "lang="
+    end
+
+    test "suggests fix for F65 (iframe titles)" do
+      pa11y_output = Jason.encode!([%{"code" => "F65", "message" => "iframe without title"}])
+
+      {:ok, result} = SuggestFixes.execute(%{"pa11y_output" => pa11y_output}, [])
+
+      [suggestion] = result["suggestions"]
+      assert suggestion["suggestion"]["rule"] == "F65"
+      assert suggestion["suggestion"]["phoenix_fix"] =~ "title="
+    end
+
+    test "suggests fix for contrast issues" do
+      pa11y_output =
+        Jason.encode!([%{"code" => "contrast", "message" => "Color contrast is insufficient"}])
+
+      {:ok, result} = SuggestFixes.execute(%{"pa11y_output" => pa11y_output}, [])
+
+      [suggestion] = result["suggestions"]
+      assert suggestion["suggestion"]["rule"] == "Color Contrast"
+      assert suggestion["suggestion"]["phoenix_fix"] =~ "4.5:1"
+    end
+
+    test "provides generic suggestion for unknown codes" do
+      pa11y_output = Jason.encode!([%{"code" => "UNKNOWN", "message" => "Some issue"}])
+
+      {:ok, result} = SuggestFixes.execute(%{"pa11y_output" => pa11y_output}, [])
+
+      [suggestion] = result["suggestions"]
+      assert suggestion["suggestion"]["phoenix_fix"] =~ "WCAG guidelines"
+    end
+  end
+
+  describe "execute/2 with empty input" do
+    test "handles empty string" do
+      {:ok, result} = SuggestFixes.execute(%{"pa11y_output" => ""}, [])
+
+      assert result["status"] == "success"
+      assert result["issues_found"] == 0
+      assert result["suggestions"] == []
+    end
+
+    test "handles missing pa11y_output" do
+      {:ok, result} = SuggestFixes.execute(%{}, [])
+
+      assert result["status"] == "success"
+      assert result["issues_found"] == 0
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Extends the MCP server from a minimal 400-line implementation to a fully-featured, modular server
- Adds auto-discovery registry for tools, resources, and prompts
- Implements MCP resources and prompts support
- Adds 2 new tools for enhanced accessibility workflow

## Changes

### New Behaviours
- `Excessibility.MCP.Tool` - Tool behaviour with `name/0`, `description/0`, `input_schema/0`, `execute/2`
- `Excessibility.MCP.Resource` - Resource behaviour with `uri_pattern/0`, `name/0`, `description/0`, `mime_type/0`, `list/0`, `read/1`
- `Excessibility.MCP.Prompt` - Prompt behaviour with `name/0`, `description/0`, `arguments/0`, `get/1`

### Registry
- Compile-time auto-discovery from `tools/`, `resources/`, `prompts/` directories
- Runtime merge with custom config (`:custom_mcp_tools`, `:custom_mcp_resources`, `:custom_mcp_prompts`)

### Tools (6 total)
- `e11y_check` - Run Pa11y accessibility checks (migrated)
- `e11y_debug` - Run tests with telemetry capture (migrated)
- `get_timeline` - Read captured timeline (migrated)
- `get_snapshots` - List/read HTML snapshots (migrated)
- `analyze_timeline` - **NEW**: Run analyzers on existing timeline without re-running tests
- `suggest_fixes` - **NEW**: Parse Pa11y output and suggest Phoenix-specific WCAG fixes

### Resources (3 types)
- `timeline://latest` - Latest timeline capture
- `snapshot://{name}` - HTML snapshots
- `config://excessibility`, `config://pa11y` - Configuration

### Prompts (2)
- `fix-a11y-issue` - Generate prompts for fixing WCAG violations
- `debug-liveview` - Generate prompts for debugging LiveView state issues

### Server
- Refactored to GenServer architecture
- Added handlers for `resources/list`, `resources/read`, `prompts/list`, `prompts/get`
- Updated capabilities to advertise resources and prompts support

## Test plan

- [x] All 435 tests pass
- [x] `mix credo --strict` passes
- [x] `mix format --check-formatted` passes
- [x] Verified tools/list returns 6 tools
- [x] Verified resources/list returns timeline, snapshots, config resources
- [x] Verified prompts/list returns 2 prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)