### PR TITLE
fix: include bin/ directory in Hex package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-02-03
+
+### Fixed
+- Include `bin/` directory in Hex package so `bin/mcp-server` is available when installed as a dependency
+
 ## [0.10.0] - 2026-02-01
 
 ### Fixed

--- a/lib/excessibility/mcp/server.ex
+++ b/lib/excessibility/mcp/server.ex
@@ -27,7 +27,7 @@ defmodule Excessibility.MCP.Server do
 
   @server_info %{
     "name" => "excessibility",
-    "version" => "0.10.0"
+    "version" => "0.10.1"
   }
 
   @capabilities %{

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Excessibility.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/lessthanseventy/excessibility"
-  @version "0.10.0"
+  @version "0.10.1"
 
   def project do
     [
@@ -52,7 +52,7 @@ defmodule Excessibility.MixProject do
 
   defp package do
     [
-      files: ["lib", "assets", "mix.exs", "README*", "LICENSE*"],
+      files: ["lib", "assets", "bin", "mix.exs", "README*", "LICENSE*"],
       maintainers: ["Andrew Moore"],
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/lessthanseventy/excessibility"}


### PR DESCRIPTION
## Summary
- Add `bin/` to package files list so `bin/mcp-server` is available when installed from Hex
- Bump version to 0.10.1

## Test plan
- [ ] Verify `bin/mcp-server` is included when running `mix hex.build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)