### PR TITLE
fix: resolve CI failures for v0.12.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Add to `mix.exs`:
 ```elixir
 def deps do
   [
-    {:excessibility, "~> 0.11", only: [:dev, :test]}
+    {:excessibility, "~> 0.12", only: [:dev, :test]}
   ]
 end
 ```


### PR DESCRIPTION
## Summary
- Fix credo --strict issues in new analyzers (assign_diff, component_rerender, ecto_query_analysis, message_flooding, push_event_volume)
- Include source hash in CI cache key to prevent stale beams
- Update README dependency version from `~> 0.11` to `~> 0.12` to match mix.exs (fixes Version Tag CI check)

## Test plan
- [ ] CI passes (both CI and Version Tag workflows)
- [ ] `mix credo --strict` passes locally
- [ ] `mix test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)