### PR TITLE
fix(rules): scope LiveView a11y rules to stop false positives (#110)

### DIFF
--- a/lib/excessibility/live_view_rules/rules/click_away_without_escape.ex
+++ b/lib/excessibility/live_view_rules/rules/click_away_without_escape.ex
@@ -72,9 +72,7 @@ defmodule Excessibility.LiveViewRules.Rules.ClickAwayWithoutEscape do
     %{
       rule: id(),
       severity: :serious,
-      message:
-        "<#{tag}> uses phx-click-away for dismissal but has no keyboard " <>
-          "equivalent. Keyboard and screen-reader users cannot close this overlay.",
+      message: build_message(tag, attrs),
       element: element |> Floki.raw_html() |> String.slice(0, 300),
       selector: build_selector(tag, attrs),
       help:
@@ -83,6 +81,30 @@ defmodule Excessibility.LiveViewRules.Rules.ClickAwayWithoutEscape do
           "dialogs, use `role=\"dialog\"` with proper focus management.",
       help_url: "https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/"
     }
+  end
+
+  # A keydown handler is present but phx-key is "escape"/"ESCAPE"/etc. rather
+  # than the exact DOM value "Escape", so Escape dismissal silently never
+  # fires. Common, hard-to-spot pitfall — call it out specifically (#110).
+  defp build_message(tag, attrs) do
+    if miscased_escape?(attrs) do
+      key = find_attr(attrs, "phx-key")
+
+      "<#{tag}> has a keydown handler with phx-key=\"#{key}\", but phx-key is matched " <>
+        "literally against KeyboardEvent.key — it must be capitalized as \"Escape\". " <>
+        "As written, Escape dismissal silently never fires."
+    else
+      "<#{tag}> uses phx-click-away for dismissal but has no keyboard equivalent. " <>
+        "Keyboard and screen-reader users cannot close this overlay. Add phx-window-keydown " <>
+        "with phx-key=\"Escape\" (must match KeyboardEvent.key exactly — capitalized)."
+    end
+  end
+
+  defp miscased_escape?(attrs) do
+    has_keydown? = has_attr?(attrs, "phx-keydown") or has_attr?(attrs, "phx-window-keydown")
+    key = find_attr(attrs, "phx-key")
+
+    has_keydown? and is_binary(key) and String.downcase(key) == "escape" and key != "Escape"
   end
 
   defp find_attr(attrs, name) do

--- a/lib/excessibility/live_view_rules/rules/phx_click_on_non_interactive.ex
+++ b/lib/excessibility/live_view_rules/rules/phx_click_on_non_interactive.ex
@@ -8,9 +8,14 @@ defmodule Excessibility.LiveViewRules.Rules.PhxClickOnNonInteractive do
   unreachable by keyboard users — no focus, no Enter/Space handling, no
   assistive-tech affordances.
 
+  `phx-click-away` is **not** flagged here: it fires when the user clicks
+  *elsewhere*, so the element is never an activation target and does not need
+  to be keyboard-focusable. Keyboard dismissal of click-away overlays is
+  covered by `click_away_without_escape`.
+
   ## What's flagged
 
-  Any element carrying `phx-click` (or `phx-click-away`) that is **not**:
+  Any element carrying `phx-click` that is **not**:
 
     * a natively interactive element (`<a>`, `<button>`, `<input>`,
       `<select>`, `<textarea>`, `<summary>`, `<details>`)
@@ -50,7 +55,7 @@ defmodule Excessibility.LiveViewRules.Rules.PhxClickOnNonInteractive do
   @impl true
   def check(tree, _opts) do
     tree
-    |> Floki.find("[phx-click], [phx-click-away]")
+    |> Floki.find("[phx-click]")
     |> Enum.reject(&interactive?/1)
     |> Enum.map(&build_finding/1)
   end
@@ -70,13 +75,11 @@ defmodule Excessibility.LiveViewRules.Rules.PhxClickOnNonInteractive do
   defp interactive?(_), do: false
 
   defp build_finding({tag, attrs, _children} = element) do
-    event_attr = offending_attr(attrs)
-
     %{
       rule: id(),
       severity: :serious,
       message:
-        "<#{tag}> has #{event_attr} but is not keyboard-accessible. " <>
+        "<#{tag}> has phx-click but is not keyboard-accessible. " <>
           "Use <button>/<a>, or add tabindex=\"0\" with an interactive role and keyboard handlers.",
       element: element |> Floki.raw_html() |> String.slice(0, 300),
       selector: build_selector(tag, attrs),
@@ -85,18 +88,6 @@ defmodule Excessibility.LiveViewRules.Rules.PhxClickOnNonInteractive do
           "or make the element focusable (tabindex=\"0\") with a proper role and keyboard event handlers.",
       help_url: "https://www.w3.org/WAI/ARIA/apg/patterns/button/"
     }
-  end
-
-  defp offending_attr(attrs) do
-    cond do
-      has_attr?(attrs, "phx-click") -> "phx-click"
-      has_attr?(attrs, "phx-click-away") -> "phx-click-away"
-      true -> "a phx-* click handler"
-    end
-  end
-
-  defp has_attr?(attrs, name) do
-    Enum.any?(attrs, fn {n, _} -> n == name end)
   end
 
   defp build_selector(tag, attrs) do

--- a/lib/excessibility/live_view_rules/rules/toggle_missing_aria_state.ex
+++ b/lib/excessibility/live_view_rules/rules/toggle_missing_aria_state.ex
@@ -46,45 +46,77 @@ defmodule Excessibility.LiveViewRules.Rules.ToggleMissingAriaState do
   def default_enabled?, do: true
 
   @impl true
-  def check(tree, _opts) do
-    tree
-    |> Floki.find("[phx-click]")
-    |> Enum.flat_map(&maybe_finding/1)
-  end
+  def check(tree, _opts), do: collect(tree, [])
 
   # ── Implementation ────────────────────────────────────────────────
 
-  defp maybe_finding({_tag, attrs, _children} = element) do
+  # Walk the tree depth-first, tracking the ids of the current element's
+  # ancestors so a toggle that targets its own container can be recognized
+  # as a dismisser rather than a disclosure toggler.
+  defp collect(nodes, ancestor_ids) when is_list(nodes), do: Enum.flat_map(nodes, &collect(&1, ancestor_ids))
+
+  defp collect({_tag, attrs, children} = element, ancestor_ids) do
+    findings = maybe_finding(element, ancestor_ids)
+
+    child_ancestors =
+      case find_attr(attrs, "id") do
+        nil -> ancestor_ids
+        id -> [id | ancestor_ids]
+      end
+
+    findings ++ collect(children, child_ancestors)
+  end
+
+  # Text/comment nodes have no children to recurse into.
+  defp collect(_node, _ancestor_ids), do: []
+
+  defp maybe_finding({_tag, attrs, _children} = element, ancestor_ids) do
     with value when is_binary(value) <- find_attr(attrs, "phx-click"),
-         {:ok, targets} <- toggle_targets(value) do
-      if has_attr?(attrs, "aria-expanded") do
-        []
-      else
-        [build_finding(element, targets)]
+         {:ok, ops} <- toggle_ops(value) do
+      cond do
+        has_attr?(attrs, "aria-expanded") -> []
+        # Hide-only is a dismiss, not a disclosure toggle — aria-expanded
+        # would be permanently wrong on a close button.
+        dismiss_only?(ops) -> []
+        # Toggling an ancestor container means closing the thing you live
+        # inside (e.g. a menu item that dismisses its own menu).
+        closes_own_container?(ops, ancestor_ids) -> []
+        true -> [build_finding(element, op_targets(ops))]
       end
     else
       _ -> []
     end
   end
 
-  defp toggle_targets(value) do
+  defp toggle_ops(value) do
     case Jason.decode(value) do
       {:ok, ops} when is_list(ops) ->
-        targets = extract_toggle_targets(ops)
-        if targets == [], do: :not_a_toggle, else: {:ok, targets}
+        extracted = extract_ops(ops)
+        if extracted == [], do: :not_a_toggle, else: {:ok, extracted}
 
       _ ->
         :not_a_toggle
     end
   end
 
-  defp extract_toggle_targets(ops) do
+  defp extract_ops(ops) do
     Enum.flat_map(ops, fn
-      [op, %{"to" => target}] when op in @toggle_ops -> [target]
-      [op, _params] when op in @toggle_ops -> [nil]
+      [op, %{"to" => target}] when op in @toggle_ops -> [{op, target}]
+      [op, _params] when op in @toggle_ops -> [{op, nil}]
       _ -> []
     end)
   end
+
+  defp dismiss_only?(ops), do: Enum.all?(ops, fn {op, _target} -> op == "hide" end)
+
+  defp closes_own_container?(ops, ancestor_ids) do
+    Enum.any?(ops, fn
+      {_op, "#" <> id} -> id in ancestor_ids
+      _ -> false
+    end)
+  end
+
+  defp op_targets(ops), do: Enum.map(ops, fn {_op, target} -> target end)
 
   defp build_finding({tag, attrs, _children} = element, targets) do
     %{

--- a/test/live_view_rules/rules/click_away_without_escape_test.exs
+++ b/test/live_view_rules/rules/click_away_without_escape_test.exs
@@ -59,4 +59,22 @@ defmodule Excessibility.LiveViewRules.Rules.ClickAwayWithoutEscapeTest do
       assert [] = findings(html)
     end
   end
+
+  describe "phx-key case-sensitivity (issue #110)" do
+    # phx-key matches KeyboardEvent.key literally, so "escape" (lowercase)
+    # silently never fires. Still a finding, but with a targeted message.
+    test "miscased escape with a keydown handler is flagged with a capitalization hint" do
+      html = ~s(<div phx-click-away="close" phx-window-keydown="close" phx-key="escape">Panel</div>)
+      assert [finding] = findings(html)
+      assert finding.message =~ "Escape"
+      assert finding.message =~ "phx-key"
+      assert finding.message =~ ~r/capitali/i
+    end
+
+    test "the generic message mentions the capitalized KeyboardEvent.key value" do
+      html = ~s(<div phx-click-away="close">Panel</div>)
+      assert [finding] = findings(html)
+      assert finding.message =~ "Escape"
+    end
+  end
 end

--- a/test/live_view_rules/rules/phx_click_on_non_interactive_test.exs
+++ b/test/live_view_rules/rules/phx_click_on_non_interactive_test.exs
@@ -37,10 +37,27 @@ defmodule Excessibility.LiveViewRules.Rules.PhxClickOnNonInteractiveTest do
       assert [%{selector: "tr"}] = findings(html)
     end
 
-    test "phx-click-away on non-interactive element" do
-      html = ~s(<div phx-click-away="close">Panel</div>)
+    test "element with BOTH phx-click and phx-click-away is still flagged for the click" do
+      html = ~s(<div phx-click="activate" phx-click-away="close">Panel</div>)
       assert [finding] = findings(html)
-      assert finding.message =~ "phx-click-away"
+      assert finding.message =~ "phx-click"
+    end
+  end
+
+  describe "ignores phx-click-away (dismissal, not activation)" do
+    # phx-click-away fires when the user clicks *elsewhere* — the element is not
+    # a click target, so it does not need to be keyboard-focusable. Keyboard
+    # dismissal is click_away_without_escape's concern. See issue #110.
+    test "div with only phx-click-away" do
+      html = ~s(<div phx-click-away="close">Panel</div>)
+      assert [] = findings(html)
+    end
+
+    test "dialog focus-wrap pattern (click-away + window keydown)" do
+      html =
+        ~s(<div phx-click-away="close" phx-window-keydown="close" phx-key="Escape">Dialog body</div>)
+
+      assert [] = findings(html)
     end
   end
 

--- a/test/live_view_rules/rules/toggle_missing_aria_state_test.exs
+++ b/test/live_view_rules/rules/toggle_missing_aria_state_test.exs
@@ -27,8 +27,51 @@ defmodule Excessibility.LiveViewRules.Rules.ToggleMissingAriaStateTest do
       assert [_] = findings(html)
     end
 
-    test "button with JS.hide and no ARIA" do
-      html = ~s(<button phx-click='#{js("hide")}'>Hide</button>)
+    test "div that toggles AND hides (mixed ops) and no ARIA" do
+      html = ~s(<div phx-click='[["toggle",{"to":"#menu"}],["hide",{"to":"#other"}]]'>Open</div>)
+      assert [_] = findings(html)
+    end
+  end
+
+  describe "does not flag dismissers" do
+    # A hide-only action is a dismiss, not a disclosure toggle. aria-expanded
+    # belongs on the control that *shows* the target, not on a close button —
+    # its value would be permanently wrong here. See issue #110.
+    test "hide-only close button" do
+      html = ~s(<button phx-click='#{js("hide", "#disconnected")}' aria-label="close">x</button>)
+      assert [] = findings(html)
+    end
+
+    test "hide-only with a push op (flash clear pattern)" do
+      html =
+        ~s(<button phx-click='[["push",{"event":"lv:clear-flash"}],["hide",{"to":"#flash"}]]'>x</button>)
+
+      assert [] = findings(html)
+    end
+
+    # A toggle whose target is the element's own ancestor container is closing
+    # the container it lives in (e.g. a menu item that dismisses its menu), not
+    # a disclosure toggler. The owning toggler lives outside the container.
+    test "menu item toggling its own ancestor container" do
+      html = """
+      <div id="filter-menu-product" role="menu">
+        <button phx-click='#{js("toggle", "#filter-menu-product")}'>Select product</button>
+      </div>
+      """
+
+      assert [] = findings(html)
+    end
+  end
+
+  describe "still flags real togglers" do
+    # A toggler that opens a target it is NOT inside (e.g. a hamburger button)
+    # must still expose aria-expanded.
+    test "opener toggling a sibling container" do
+      html = """
+      <button phx-click='#{js("toggle", "#menu")}'>Menu</button>
+      <div id="menu" role="menu">...</div>
+      """
+
       assert [_] = findings(html)
     end
   end


### PR DESCRIPTION
Closes #110.

Three JS-aware LiveView rules were firing on dismiss/dialog patterns where the ARIA fix they suggested would actually be *wrong*, drowning real findings in noise — the reporter saw **57 of 58** remaining violations come from this.

## Changes

### `toggle_missing_aria_state`
Now walks the tree tracking ancestor ids and skips two dismiss patterns where `aria-expanded` would be incorrect:
- **Hide-only actions** (`JS.hide` with no `toggle`/`show`) — a dismiss, not a disclosure toggle. Covers flash close buttons and modal "I understand" / `hide_modal` buttons.
- **Toggles whose target is the element's own ancestor container** — e.g. a menu item that closes its own menu. The owning toggler lives outside the container.

A real toggler (e.g. a hamburger opening a sibling container it is *not* inside) is still flagged.

### `phx_click_on_non_interactive`
No longer considers `phx-click-away`. Click-away fires on clicks *elsewhere*, so the element is never an activation target and needn't be keyboard-focusable — that concern (keyboard dismissal) belongs to `click_away_without_escape`. This removes the false positives on the standard dialog `focus_wrap` pattern. Elements carrying `phx-click` are unchanged (and an element with *both* is still flagged for the click).

### `click_away_without_escape`
Detects the common silent-failure where a keydown handler is paired with a miscased `phx-key` (`"escape"` instead of the literal `"Escape"` that matches `KeyboardEvent.key`) and emits a pointed message. The generic message now also notes the required capitalization.

## Testing
- New/updated unit tests for all three rules (two old tests that locked in the buggy behavior were corrected).
- Full suite green: **645 tests, 0 failures**; `mix credo` clean; compiles with `--warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)