### PR TITLE
feat: embed capture metadata in default snapshots (cross-snapshot diffing)

### DIFF
--- a/lib/capture.ex
+++ b/lib/capture.ex
@@ -12,16 +12,29 @@ defmodule Excessibility.Capture do
   @doc """
   Initializes capture state for a test.
   """
-  def init_capture(test_name, opts \\ []) do
+  def init_capture(test_name, opts \\ [], mode \\ :auto) do
     state = %{
       test_name: test_name,
       sequence: 0,
       events: [],
       opts: opts,
+      mode: mode,
       start_time: DateTime.utc_now()
     }
 
     Process.put(:excessibility_capture_state, state)
+  end
+
+  @doc """
+  Initializes a lightweight `:default`-mode context for a test.
+
+  Unlike `init_capture/3` (`:auto` mode, used by the `capture_snapshots`
+  tag), this only records the test name and a per-call sequence so that
+  every snapshot embeds `Test:`/`Sequence:` metadata for cross-snapshot
+  diffing — the default `Module_line.html` filename scheme is preserved.
+  """
+  def init_default_context(test_name) do
+    init_capture(test_name, [], :default)
   end
 
   @doc """
@@ -67,6 +80,7 @@ defmodule Excessibility.Capture do
           timestamp: event.timestamp,
           assigns: assigns,
           previous: get_previous_snapshot_name(state),
+          mode: Map.get(state, :mode, :auto),
           opts: state.opts
         }
     end

--- a/lib/excessibility.ex
+++ b/lib/excessibility.ex
@@ -66,16 +66,27 @@ defmodule Excessibility do
       import Excessibility, only: [html_snapshot: 1, html_snapshot: 2]
 
       setup context do
+        telemetry? = System.get_env("EXCESSIBILITY_TELEMETRY_CAPTURE") == "true"
+
         # Store test name for telemetry capture
-        if System.get_env("EXCESSIBILITY_TELEMETRY_CAPTURE") == "true" do
-          test_name = context[:test]
-          Process.put(:excessibility_test_name, test_name)
-          Excessibility.TelemetryCapture.clear_snapshots(test_name)
+        if telemetry? do
+          Process.put(:excessibility_test_name, context[:test])
+          Excessibility.TelemetryCapture.clear_snapshots(context[:test])
         end
 
-        if context[:capture_snapshots] || context[:capture] do
-          test_name = context[:test]
-          Excessibility.Capture.init_capture(test_name, context)
+        cond do
+          context[:capture_snapshots] || context[:capture] ->
+            Excessibility.Capture.init_capture(context[:test], context)
+
+          # Default-mode context: embeds Test/Sequence metadata in ordinary
+          # snapshots (module-qualified test key avoids collisions between
+          # same-named tests in different modules) so cross-snapshot diffing
+          # can pair them. Skipped under telemetry, which manages its own.
+          not telemetry? ->
+            Excessibility.Capture.init_default_context("#{inspect(context[:module])} #{context[:test]}")
+
+          true ->
+            :ok
         end
 
         on_exit(fn ->

--- a/lib/snapshot.ex
+++ b/lib/snapshot.ex
@@ -85,8 +85,10 @@ defmodule Excessibility.Snapshot do
       opts[:name] ->
         opts[:name]
 
-      # Auto-capture mode with metadata
-      metadata ->
+      # Auto-capture (telemetry) mode names files by test/sequence/event.
+      # Default-mode metadata is written into the snapshot comment but does
+      # NOT change the filename scheme.
+      auto_capture?(metadata) ->
         "#{metadata.test_name}_#{metadata.sequence}_#{metadata.event_type}.html"
 
       # Default: module_line.html
@@ -94,6 +96,9 @@ defmodule Excessibility.Snapshot do
         "#{module |> to_string() |> String.replace(".", "_")}_#{env.line}.html"
     end
   end
+
+  defp auto_capture?(%{mode: :auto}), do: true
+  defp auto_capture?(_), do: false
 
   defp get_capture_metadata(source, opts) do
     # Check if we're in auto-capture mode

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -64,4 +64,25 @@ defmodule Excessibility.MacroIntegrationTest do
            "Expected snapshot file matching #{expected_pattern}, but found none. " <>
              "Dir contents: #{inspect(File.ls!(@snapshot_dir))}"
   end
+
+  test "default snapshots embed Test/Sequence metadata without changing the filename" do
+    conn =
+      :get
+      |> Plug.Test.conn("/")
+      |> Plug.Conn.put_resp_content_type("text/html")
+      |> Plug.Conn.send_resp(200, "<h1>Hello World</h1>")
+
+    html_snapshot(conn)
+
+    files = Path.wildcard(Path.join(@snapshot_dir, "Elixir_Excessibility_MacroIntegrationTest_*.html"))
+    assert [file | _] = files
+
+    content = File.read!(file)
+    # The default Module_line.html name is preserved (matched by the wildcard
+    # above) but the snapshot now carries capture metadata for cross-snapshot
+    # diffing.
+    assert content =~ "Excessibility Snapshot"
+    assert content =~ "Test:"
+    assert content =~ "Sequence:"
+  end
 end


### PR DESCRIPTION
Follow-up to #104 (cross-snapshot diffing).

## Problem

The cross-snapshot a11y check can only pair snapshots it can attribute to the same test, in order. It does that via the embedded `Test:`/`Sequence:` capture-metadata comment. But **default `Module_line.html` snapshots carry no such metadata** — and the filename alone has no reliable test boundary (two `html_snapshot` calls in one test look the same as two calls across two different tests). So cross-snapshot diffing only worked for telemetry/auto-capture snapshots.

The obvious fix — rename default snapshots — is the wrong one: filenames are load-bearing (baselines, `compare`, `cleanup` all match by name), so renaming churns everyone's committed baselines.

## Approach

Give every test a lightweight **default-mode capture context** so ordinary snapshots embed the metadata comment, **without changing the filename scheme**.

- **`Capture`**: `init_capture/3` gains a `mode` (`:auto` by default, preserving the `capture_snapshots` tag behavior). `init_default_context/1` sets `:default` mode. `record_event` reports the mode.
- **`use Excessibility`**: the injected `setup` now initializes a default-mode context for every non-telemetry, non-tagged test, keyed by a **module-qualified** test name (`"MyApp.FooTest test renders"`) so same-named tests in different modules don't get chained together. ExUnit runs each test in its own process, so the per-call sequence counter is naturally per-test.
- **`Snapshot.get_filename`**: only `:auto` mode uses the `test_sequence_event.html` name; `:default` mode keeps `Module_line.html` and just writes the metadata comment.

Net: cross-snapshot diffing now works for **every** test's snapshots, filenames unchanged, zero baseline churn. The comment is invisible to axe and to users, and gives every snapshot real test+sequence provenance as a bonus.

## Scope / dependency

This PR only makes default snapshots *eligible* for pairing. The diff engine + `mix excessibility` wiring live in #104; this is useful once that merges.

## Testing
- New test asserts a default snapshot embeds `Test:`/`Sequence:` metadata while keeping its `Module_line.html` name.
- Existing `capture_snapshots`-tagged behavior unchanged (still `:auto` mode / telemetry naming).
- Full suite green; `mix credo --strict` clean; `mix format --check-formatted` clean; compiles with `--warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)