### PR TITLE
docs: fix finding/0 type cross-reference

### DIFF
--- a/lib/excessibility/snapshot_diff.ex
+++ b/lib/excessibility/snapshot_diff.ex
@@ -62,7 +62,7 @@ defmodule Excessibility.SnapshotDiff do
 
   @doc """
   Return accessibility findings for content that changed outside any live
-  region, in the `Excessibility.LiveViewRules.Rule.finding/0` shape.
+  region, in the `t:Excessibility.LiveViewRules.Rule.finding/0` shape.
 
   A change is considered *announced* (and therefore not flagged) when the
   changed region or any of its ancestors is an `aria-live` region (a value


### PR DESCRIPTION
`mix docs` (and therefore `mix hex.publish`) emitted:

> warning: documentation references function "Excessibility.LiveViewRules.Rule.finding/0" but it is undefined or private

`finding` is a `@type`, not a function, so the ExDoc autolink in `SnapshotDiff.live_region_findings/3`'s doc needs the `t:` prefix. One-line fix; `mix docs` now builds warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)