### PR TITLE
Release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2026-08-05
+
+### Fixed
+- **Reviews now run axe-core** ([#131](https://github.com/lessthanseventy/excessibility/issues/131)). `mix excessibility.review` (and `Excessibility.Review`) scans both sides of every changed snapshot pair through the configured scanner and folds axe violations into the finding-delta — one finding per offending node, fingerprinted `{id, target}` — so a newly introduced critical (e.g. a button losing its accessible name) is `:block` and `--fail-on block` exits non-zero. If a scan fails (e.g. Playwright isn't installed) the review degrades to the LiveView rules and says so in the report's `:warnings`. Opt out with `--no-axe` (or `axe: false` in the API).
+- **False `stylesheet failed to load` when a nested `@import` fails** ([#132](https://github.com/lessthanseventy/excessibility/issues/132)). Chromium fires an `error` event on a `<link>` whose sheet loaded fine but whose nested `@import` failed, which previously warned that the stylesheet was missing and invalidated the whole run's contrast findings. The warning is now gated on `link.sheet` (null exactly when the sheet did not load or parse); failing imports are surfaced separately and accurately as `stylesheet import failed: <url> — text metrics may differ from production`.
+- **Telemetry capture no longer crashes on lists of Ecto structs** ([#133](https://github.com/lessthanseventy/excessibility/issues/133)). `Filter.filter_ecto_metadata/1` converts structs (dropping `__meta__`, `NotLoaded` becomes `nil`) instead of `Enum.reduce`-ing them, so index/detail LiveViews with `[%Schema{}]` assigns capture cleanly. Independently, `write_snapshots/1` now logs a timeline failure instead of raising out of the `on_exit` hook — instrumentation can no longer fail the test it observes.
+- **`mix excessibility.compare` in non-interactive shells** ([#134](https://github.com/lessthanseventy/excessibility/issues/134)). Without `--keep`, a non-TTY stdin (CI, editor task runners) previously crashed on `:eof` deep in the prompt and leaked `.good.html`/`.bad.html` temp files. The task now refuses up front with the actual guidance (`--keep good|bad`), cleans up temp files even when resolution errors, and if stdin closes mid-run it keeps the baseline (fail-safe) instead of silently accepting the new version.
+
+### Added
+- **`node_modules_path` config** ([#135](https://github.com/lessthanseventy/excessibility/issues/135)). `@axe-core/playwright` now gets the same override → bundled → ambient resolution as Playwright, so `config :excessibility, node_modules_path: "assets/node_modules"` reuses a host `node_modules` (providing both `playwright` and `@axe-core/playwright`) and removes the `deps/excessibility/assets` npm install from the workflow entirely. Caveat: the host then pins the axe-core version, and `engine.axe_version` in reports follows it — an axe minor bump can change finding sets vs earlier baselines.
+
 ## [0.15.0] - 2026-08-05
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,7 @@ All configuration in `test/test_helper.exs` or `config/test.exs`:
 - `:excessibility_output_path` - Base directory (default: `"test/excessibility"`)
 - `:pa11y_path` - Path to Pa11y executable (auto-detected)
 - `:playwright_path` - Path to an existing Playwright installation to reuse (default: bundled copy in `assets/`)
+- `:node_modules_path` - Path to a host `node_modules` providing `playwright` and `@axe-core/playwright` (default: bundled copy in `assets/`)
 - `:pa11y_config` - Path to pa11y.json (default: `"pa11y.json"`)
 - `:head_render_path` - Route for `<head>` extraction (default: `"/"`)
 - `:custom_enrichers` - List of custom enricher modules (default: `[]`)

--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ All configuration goes in `test/test_helper.exs` or `config/test.exs`:
 | `:excessibility_output_path` | No | `"test/excessibility"` | Base directory for snapshots |
 | `:axe_runner_path` | No | auto-detected | Path to axe-runner.js script |
 | `:playwright_path` | No | bundled copy | Path to an existing Playwright installation to reuse (skips the second browser download) |
+| `:node_modules_path` | No | bundled copy | Path to a host `node_modules` directory providing `playwright` **and** `@axe-core/playwright` (skips the bundled `npm install` entirely; pins the axe version to the host's) |
 | `:viewports` | No | `[]` | `{width, height}` tuples for `mix excessibility` to scan each snapshot at |
 | `:check_clipping` | No | `false` | Flag interactive elements mostly outside the visible area, plus page-level horizontal overflow |
 | `:clipping_ratio` | No | `0.9` | Minimum visible-width ratio before an element counts as clipped |

--- a/assets/axe-crawl.js
+++ b/assets/axe-crawl.js
@@ -9,9 +9,9 @@
 // Outputs JSON with axe results for each stage reached.
 
 const path = require("path");
-const { resolvePlaywright, modulesDir } = require("./resolve-playwright");
+const { resolvePlaywright, resolveAxeBuilder } = require("./resolve-playwright");
 const { chromium } = resolvePlaywright();
-const { AxeBuilder } = require(path.join(modulesDir, "@axe-core", "playwright"));
+const AxeBuilder = resolveAxeBuilder();
 
 // ── Heuristic selectors ────────────────────────────────────
 

--- a/assets/axe-runner.js
+++ b/assets/axe-runner.js
@@ -121,23 +121,31 @@ function parseArgs(argv) {
 // stylesheet has either loaded or errored, then report failures so
 // callers know styled-dependent findings can't be trusted.
 async function installStylesheetTracker(page) {
+  // The flag only feeds the wait predicate below. Chromium also fires this
+  // error event when the sheet loaded fine but a nested @import failed, so
+  // it cannot be used to decide whether the stylesheet itself is missing —
+  // link.sheet is the authoritative signal for that.
   await page.addInitScript(() => {
-    window.__excessibilityFailedStylesheets = [];
     window.addEventListener(
       "error",
       (e) => {
         const t = e.target;
         if (t && t.tagName === "LINK" && (t.rel || "").includes("stylesheet")) {
           t.__excessibilityFailed = true;
-          window.__excessibilityFailedStylesheets.push(t.href);
         }
       },
       true,
     );
   });
+
+  const failedStylesheetRequests = [];
+  page.on("requestfailed", (request) => {
+    if (request.resourceType() === "stylesheet") failedStylesheetRequests.push(request.url());
+  });
+  return failedStylesheetRequests;
 }
 
-async function waitForStylesheets(page, warnings, maxWait = 10000) {
+async function waitForStylesheets(page, warnings, failedStylesheetRequests, maxWait = 10000) {
   const hasLinks = await page
     .evaluate(() => document.querySelectorAll('link[rel~="stylesheet"]').length > 0)
     .catch(() => false);
@@ -158,9 +166,26 @@ async function waitForStylesheets(page, warnings, maxWait = 10000) {
       );
     });
 
-  const failed = await page.evaluate(() => window.__excessibilityFailedStylesheets || []).catch(() => []);
+  // link.sheet is null exactly when the stylesheet did not load or parse,
+  // so a genuinely missing file warns while a loaded sheet whose nested
+  // @import failed does not.
+  const failed = await page
+    .evaluate(() =>
+      [...document.querySelectorAll('link[rel~="stylesheet"]')].filter((l) => !l.sheet).map((l) => l.href),
+    )
+    .catch(() => []);
   for (const href of failed) {
     warnings.push(`stylesheet failed to load: ${href} — contrast/layout findings are invalid until it exists`);
+  }
+
+  // A failed stylesheet request that isn't one of the missing <link>s is a
+  // nested @import (e.g. a remote font stylesheet blocked from file://).
+  // Styling is degraded, not absent — fallback fonts change text metrics.
+  const failedSet = new Set(failed);
+  for (const url of new Set(failedStylesheetRequests)) {
+    if (!failedSet.has(url)) {
+      warnings.push(`stylesheet import failed: ${url} — text metrics may differ from production`);
+    }
   }
 
   await page.evaluate(() => document.fonts && document.fonts.ready).catch(() => {});
@@ -293,7 +318,7 @@ async function main() {
   try {
     const effectiveWaitUntil = waitUntil || "load";
 
-    await installStylesheetTracker(page);
+    const failedStylesheetRequests = await installStylesheetTracker(page);
 
     let response;
     try {
@@ -333,7 +358,7 @@ async function main() {
       await waitForContent(page);
     }
 
-    await waitForStylesheets(page, warnings);
+    await waitForStylesheets(page, warnings, failedStylesheetRequests);
 
     const runAxe = async () => {
       let builder = new AxeBuilder({ page }).withTags(tags);

--- a/assets/axe-runner.js
+++ b/assets/axe-runner.js
@@ -3,10 +3,9 @@
 // to stdout and exits 1. The Elixir Excessibility.Scanner module parses
 // both shapes.
 
-const path = require("path");
-const { resolvePlaywright, launchErrorHint, modulesDir } = require("./resolve-playwright");
+const { resolvePlaywright, resolveAxeBuilder, launchErrorHint } = require("./resolve-playwright");
 const { chromium } = resolvePlaywright();
-const { AxeBuilder } = require(path.join(modulesDir, "@axe-core", "playwright"));
+const AxeBuilder = resolveAxeBuilder();
 
 const USAGE =
   "Usage: node axe-runner.js <url> " +

--- a/assets/resolve-playwright.js
+++ b/assets/resolve-playwright.js
@@ -1,10 +1,13 @@
-// Resolves the Playwright installation shared by axe-runner.js and
-// axe-crawl.js. Resolution order:
+// Resolves the node modules shared by axe-runner.js and axe-crawl.js
+// (playwright and @axe-core/playwright). Resolution order:
 //
 //   1. EXCESSIBILITY_PLAYWRIGHT_PATH (set via `config :excessibility,
-//      playwright_path: "..."`) — reuse a host project's installation
-//   2. the bundled copy under assets/node_modules
-//   3. ambient Node resolution (project node_modules / NODE_PATH)
+//      playwright_path: "..."`) — reuse a host project's Playwright
+//   2. EXCESSIBILITY_NODE_MODULES_PATH (set via `config :excessibility,
+//      node_modules_path: "..."`) — reuse a host node_modules directory
+//      for every module, not just Playwright
+//   3. the bundled copy under assets/node_modules
+//   4. ambient Node resolution (project node_modules / NODE_PATH)
 //
 // Failures emit the same {error, message} JSON shape the Elixir side
 // already parses, with an actionable command instead of a bare stack.
@@ -16,6 +19,34 @@ const modulesDir = path.join(__dirname, "node_modules");
 function fail(message) {
   console.log(JSON.stringify({ error: "playwright_error", message }));
   process.exit(1);
+}
+
+// An explicitly configured node_modules override is intent, so a miss
+// there is an error rather than a silent fall-through to the bundled
+// copy — otherwise a typo'd path quietly changes which axe version runs.
+function resolveModule(name, notFoundHint) {
+  const segments = name.split("/");
+
+  const override = process.env.EXCESSIBILITY_NODE_MODULES_PATH;
+  if (override) {
+    try {
+      return require(path.join(override, ...segments));
+    } catch (err) {
+      return fail(`failed to load ${name} from EXCESSIBILITY_NODE_MODULES_PATH=${override}: ${err.message}`);
+    }
+  }
+
+  try {
+    return require(path.join(modulesDir, ...segments));
+  } catch {
+    // fall through to ambient resolution
+  }
+
+  try {
+    return require(name);
+  } catch {
+    return fail(notFoundHint);
+  }
 }
 
 function resolvePlaywright() {
@@ -30,20 +61,20 @@ function resolvePlaywright() {
     }
   }
 
-  try {
-    return require(path.join(modulesDir, "playwright"));
-  } catch {
-    // fall through to ambient resolution
-  }
+  return resolveModule(
+    "playwright",
+    `playwright not found. Run: cd ${__dirname} && npm install && npx playwright install chromium — ` +
+      "or set `config :excessibility, playwright_path: ...` (or `node_modules_path: ...`) to reuse an existing installation",
+  );
+}
 
-  try {
-    return require("playwright");
-  } catch {
-    return fail(
-      `playwright not found. Run: cd ${__dirname} && npm install && npx playwright install chromium — ` +
-        "or set `config :excessibility, playwright_path: ...` to reuse an existing installation",
-    );
-  }
+function resolveAxeBuilder() {
+  const mod = resolveModule(
+    "@axe-core/playwright",
+    `@axe-core/playwright not found. Run: cd ${__dirname} && npm install — ` +
+      "or set `config :excessibility, node_modules_path: ...` to reuse a host node_modules that provides it",
+  );
+  return mod.AxeBuilder;
 }
 
 // Playwright's own launch error says "npx playwright install" without
@@ -57,4 +88,4 @@ function launchErrorHint() {
   return `To download browsers for the bundled Playwright, run: cd ${__dirname} && npx playwright install chromium`;
 }
 
-module.exports = { resolvePlaywright, launchErrorHint, modulesDir };
+module.exports = { resolvePlaywright, resolveAxeBuilder, resolveModule, launchErrorHint, modulesDir };

--- a/lib/excessibility/mcp/tools/diff_snapshots.ex
+++ b/lib/excessibility/mcp/tools/diff_snapshots.ex
@@ -50,7 +50,8 @@ defmodule Excessibility.MCP.Tools.DiffSnapshots do
        "tier" => Atom.to_string(change.tier),
        "regions_changed" => change.region_count,
        "regions" => Enum.map(change.regions, &region/1),
-       "findings" => Enum.map(change.findings, &finding/1)
+       "findings" => Enum.map(change.findings, &finding/1),
+       "warnings" => change.warnings
      }}
   end
 
@@ -70,7 +71,8 @@ defmodule Excessibility.MCP.Tools.DiffSnapshots do
 
   defp finding(finding) do
     %{
-      "rule" => Atom.to_string(finding.rule),
+      # axe rule ids are strings, LiveView rule ids are atoms
+      "rule" => to_string(finding.rule),
       "severity" => Atom.to_string(finding.severity),
       "selector" => finding.selector,
       "message" => finding.message

--- a/lib/excessibility/review.ex
+++ b/lib/excessibility/review.ex
@@ -8,10 +8,16 @@ defmodule Excessibility.Review do
   state) and, per view, reports:
 
     * the rendered regions that changed (via `Excessibility.SnapshotDiff`)
-    * the accessibility findings this change **newly introduced** — rule
-      violations present now but not in the baseline (a finding-delta), plus
-      content that changed without an `aria-live` announcement
+    * the accessibility findings this change **newly introduced** —
+      axe-core violations and `Excessibility.LiveViewRules` violations
+      present now but not in the baseline (a finding-delta), plus content
+      that changed without an `aria-live` announcement
     * a risk **tier** — `:auto`, `:review`, or `:block`
+
+  axe-core runs through the configured `:scanner_mod` (a browser scan of
+  each side of the pair); disable it with `axe: false`. When a scan fails
+  (e.g. Playwright isn't installed) the review still runs on the LiveView
+  rules alone and says so in the report's `:warnings`.
 
   The tier is a transparent heuristic over the new findings; a smarter
   judge can be layered on top of the same report. Because it diffs against
@@ -32,12 +38,14 @@ defmodule Excessibility.Review do
           region_count: non_neg_integer(),
           findings: [map()],
           behavioral: [Behavioral.finding()],
+          warnings: [String.t()],
           tier: tier()
         }
 
   @type report :: %{
           changes: [change()],
           behavioral: [Behavioral.finding()],
+          warnings: [String.t()],
           summary: %{auto: non_neg_integer(), review: non_neg_integer(), block: non_neg_integer()}
         }
 
@@ -74,12 +82,14 @@ defmodule Excessibility.Review do
   """
   @spec review_pairs([{String.t(), String.t(), String.t()}], keyword()) :: report()
   def review_pairs(pairs, opts \\ []) do
-    changes =
-      pairs
-      |> Enum.map(fn {view, baseline, current} -> review_pair(view, baseline, current, opts) end)
-      |> Enum.reject(&unchanged?/1)
+    reviewed = Enum.map(pairs, fn {view, baseline, current} -> review_pair(view, baseline, current, opts) end)
 
-    %{changes: changes, summary: summarize(changes)}
+    # Hoist warnings before dropping unchanged views: a view whose scans
+    # failed may report nothing else, but the degradation must still show.
+    warnings = reviewed |> Enum.flat_map(& &1.warnings) |> Enum.uniq()
+    changes = Enum.reject(reviewed, &unchanged?/1)
+
+    %{changes: changes, summary: summarize(changes), warnings: warnings}
   end
 
   @doc """
@@ -117,9 +127,11 @@ defmodule Excessibility.Review do
   def review_pair(view, baseline_html, current_html, opts \\ []) do
     regions = SnapshotDiff.diff(baseline_html, current_html, opts)
 
+    {axe_pair, warnings} = axe_findings_pair(baseline_html, current_html, opts)
+
     findings =
       SnapshotDiff.live_region_findings(baseline_html, current_html, opts) ++
-        new_rule_findings(baseline_html, current_html, opts)
+        new_rule_findings(baseline_html, current_html, axe_pair, opts)
 
     behavioral =
       case Keyword.get(opts, :timeline) do
@@ -133,6 +145,7 @@ defmodule Excessibility.Review do
       region_count: length(regions),
       findings: findings,
       behavioral: behavioral,
+      warnings: warnings,
       tier: tier(findings ++ behavioral)
     }
   end
@@ -157,19 +170,21 @@ defmodule Excessibility.Review do
     end
   end
 
-  # Rule violations present in the current snapshot but not the baseline,
-  # identified by {rule, selector} so pre-existing issues aren't re-flagged.
-  # Counted per fingerprint: a second identical violation behind an existing
-  # one is still new.
-  defp new_rule_findings(baseline_html, current_html, opts) do
+  # Rule violations (LiveView rules + axe) present in the current snapshot
+  # but not the baseline, identified by {rule, selector} so pre-existing
+  # issues aren't re-flagged. Counted per fingerprint: a second identical
+  # violation behind an existing one is still new.
+  defp new_rule_findings(baseline_html, current_html, {axe_baseline, axe_current}, opts) do
     baseline_counts =
       baseline_html
       |> rule_findings(opts)
+      |> Kernel.++(axe_baseline)
       |> Enum.frequencies_by(&fingerprint/1)
 
     {new_findings, _remaining} =
       current_html
       |> rule_findings(opts)
+      |> Kernel.++(axe_current)
       |> Enum.flat_map_reduce(baseline_counts, fn finding, counts ->
         key = fingerprint(finding)
 
@@ -189,6 +204,57 @@ defmodule Excessibility.Review do
   end
 
   defp fingerprint(%{rule: rule, selector: selector}), do: {rule, selector}
+
+  # ── axe-core findings ──────────────────────────────────────────────
+
+  # axe findings for both sides of the pair, via the configured scanner
+  # (each HTML string is scanned from a temp file as file://). When either
+  # scan fails the axe delta would be meaningless — everything on the side
+  # that did scan would look new — so both sides are dropped and a warning
+  # is surfaced instead.
+  defp axe_findings_pair(baseline_html, current_html, opts) do
+    if Keyword.get(opts, :axe, true) and baseline_html != current_html do
+      case {axe_scan(baseline_html), axe_scan(current_html)} do
+        {{:ok, baseline_report}, {:ok, current_report}} ->
+          {{axe_findings(baseline_report), axe_findings(current_report)}, []}
+
+        {baseline_result, current_result} ->
+          {:error, reason} = Enum.find([baseline_result, current_result], &match?({:error, _}, &1))
+          {{[], []}, ["axe scan failed (#{inspect(reason)}) — axe findings are not part of this review"]}
+      end
+    else
+      {{[], []}, []}
+    end
+  end
+
+  defp axe_scan(html) do
+    path = Path.join(System.tmp_dir!(), "excessibility_review_#{System.unique_integer([:positive])}.html")
+    File.write!(path, html)
+
+    try do
+      scanner_mod().scan("file://" <> path, [])
+    after
+      File.rm(path)
+    end
+  end
+
+  # One finding per offending node, so the count-matching delta treats a
+  # second identical violation as new — same as the LiveView rules.
+  defp axe_findings(report) do
+    for violation <- Map.get(report, :violations, []),
+        node <- violation.nodes do
+      %{
+        rule: violation.id,
+        selector: Enum.join(node.target, " "),
+        severity: violation.impact || :moderate,
+        message: violation.help
+      }
+    end
+  end
+
+  defp scanner_mod do
+    Application.get_env(:excessibility, :scanner_mod, Excessibility.Scanner)
+  end
 
   defp unchanged?(%{region_count: 0, findings: [], behavioral: []}), do: true
   defp unchanged?(_), do: false

--- a/lib/excessibility/scanner.ex
+++ b/lib/excessibility/scanner.ex
@@ -48,7 +48,16 @@ defmodule Excessibility.Scanner do
 
       config :excessibility, playwright_path: "assets/node_modules/playwright"
 
-  Relative paths are expanded from the project root.
+  To skip the bundled `npm install` entirely, point Excessibility at a
+  host `node_modules` directory that provides both `playwright` and
+  `@axe-core/playwright`:
+
+      config :excessibility, node_modules_path: "assets/node_modules"
+
+  Relative paths are expanded from the project root. Note that resolving
+  `@axe-core/playwright` from the host also pins the axe-core version, so
+  `engine.axe_version` in reports follows the host installation — an axe
+  minor bump can change finding sets relative to earlier baselines.
   """
   @behaviour Excessibility.ScannerBehaviour
 
@@ -277,10 +286,15 @@ defmodule Excessibility.Scanner do
   end
 
   defp playwright_env do
-    case Application.get_env(:excessibility, :playwright_path) do
-      nil -> []
-      path -> [{"EXCESSIBILITY_PLAYWRIGHT_PATH", Path.expand(path)}]
-    end
+    Enum.flat_map(
+      [{"EXCESSIBILITY_PLAYWRIGHT_PATH", :playwright_path}, {"EXCESSIBILITY_NODE_MODULES_PATH", :node_modules_path}],
+      fn {var, key} ->
+        case Application.get_env(:excessibility, key) do
+          nil -> []
+          path -> [{var, Path.expand(path)}]
+        end
+      end
+    )
   end
 
   defp parse_output(output, url) do

--- a/lib/mix/tasks/excessibility_compare.ex
+++ b/lib/mix/tasks/excessibility_compare.ex
@@ -26,6 +26,10 @@ defmodule Mix.Tasks.Excessibility.Compare do
   - `--keep good` - Automatically keep all baseline versions (no changes)
   - `--keep bad` - Automatically accept all new versions as baseline
 
+  When stdin is not a TTY (CI, editor task runners), the interactive
+  prompt cannot work; the task exits with an error asking for `--keep`
+  instead of resolving diffs unattended.
+
   ## Workflow
 
   1. Run your tests to generate snapshots
@@ -71,8 +75,32 @@ defmodule Mix.Tasks.Excessibility.Compare do
       Mix.shell().info("All #{length(snapshots)} snapshot(s) match baseline.")
     else
       Mix.shell().info("Found #{length(diffs)} diff(s) out of #{length(snapshots)} snapshot(s).\n")
+      resolve_diffs(diffs, keep)
+    end
+  end
+
+  defp resolve_diffs(diffs, keep) do
+    if is_nil(keep) and not interactive?() do
+      Mix.raise("""
+      stdin is not interactive, so diffs cannot be resolved by prompting.
+      Re-run with --keep good (keep all baselines) or --keep bad (accept all new versions as baseline).
+      """)
+    end
+
+    try do
       Enum.each(diffs, &resolve_diff(&1, keep))
+    after
       cleanup_diff_files()
+    end
+  end
+
+  # OTP reports terminal: true only when stdin is a real TTY. Absent or
+  # false means a prompt would read :eof (CI, editor task runners,
+  # `zsh -c`), so there is no point opening diffs and asking.
+  defp interactive? do
+    case :io.getopts(:standard_io) do
+      opts when is_list(opts) -> Keyword.get(opts, :terminal, false) == true
+      _ -> false
     end
   end
 
@@ -132,12 +160,16 @@ defmodule Mix.Tasks.Excessibility.Compare do
     |> parse_choice()
   end
 
+  # IO.gets/1 returns :eof when stdin closes mid-run (and can return
+  # {:error, reason}). Keep the baseline in that case — unattended input
+  # must not quietly rewrite the reference version.
+  defp parse_choice(input) when input in [nil, :eof], do: keep_baseline_on_closed_stdin()
+  defp parse_choice({:error, _reason}), do: keep_baseline_on_closed_stdin()
+
   defp parse_choice(input) do
     input
-    |> case do
-      nil -> "b"
-      str -> String.trim(String.downcase(str))
-    end
+    |> String.downcase()
+    |> String.trim()
     |> case do
       choice when choice in ["g", "good"] ->
         :good
@@ -149,6 +181,11 @@ defmodule Mix.Tasks.Excessibility.Compare do
         Mix.shell().info("Unrecognized response, defaulting to bad (new version).")
         :bad
     end
+  end
+
+  defp keep_baseline_on_closed_stdin do
+    Mix.shell().info("stdin closed — kept baseline. Use --keep bad to accept new versions unattended.")
+    :good
   end
 
   defp cleanup_diff_files do

--- a/lib/mix/tasks/excessibility_review.ex
+++ b/lib/mix/tasks/excessibility_review.ex
@@ -28,6 +28,14 @@ defmodule Mix.Tasks.Excessibility.Review do
       # dead state, render thrash) captured by `mix excessibility.debug`
       mix excessibility.review --timeline test/excessibility/timeline.json --judge
 
+      # Skip the axe-core browser scans and review on the LiveView rules only
+      mix excessibility.review --no-axe
+
+  New findings are the union of axe-core violations (scanned per snapshot
+  pair through Playwright) and the LiveView rules. If the axe scan fails
+  (e.g. Playwright isn't installed), the review degrades to the LiveView
+  rules and prints a warning.
+
   Establish the baseline with `mix excessibility.baseline`.
   """
 
@@ -40,7 +48,7 @@ defmodule Mix.Tasks.Excessibility.Review do
   @impl Mix.Task
   def run(args) do
     {opts, _argv, _invalid} =
-      OptionParser.parse(args, strict: [fail_on: :string, judge: :boolean, timeline: :string])
+      OptionParser.parse(args, strict: [fail_on: :string, judge: :boolean, timeline: :string, axe: :boolean])
 
     fail_on = parse_fail_on(opts[:fail_on])
 
@@ -57,9 +65,11 @@ defmodule Mix.Tasks.Excessibility.Review do
   # behavioral findings — N+1 queries, dead state, render thrash — inform the
   # review alongside the DOM diff.
   defp review_opts(opts) do
+    base = [axe: Keyword.get(opts, :axe, true)]
+
     case opts[:timeline] do
-      nil -> []
-      path -> [timeline: load_timeline!(path)]
+      nil -> base
+      path -> [timeline: load_timeline!(path)] ++ base
     end
   end
 
@@ -117,11 +127,13 @@ defmodule Mix.Tasks.Excessibility.Review do
 
   defp parse_fail_on(other), do: Mix.raise("Unknown --fail-on value #{inspect(other)}. Use block, review, or never.")
 
-  defp print_report(%{changes: [], behavioral: []}) do
+  defp print_report(%{changes: [], behavioral: []} = report) do
+    print_warnings(Map.get(report, :warnings, []))
     Mix.shell().info("No changes vs baseline.")
   end
 
   defp print_report(%{changes: changes, summary: summary} = report) do
+    print_warnings(Map.get(report, :warnings, []))
     Mix.shell().info("## Blast radius vs baseline\n")
 
     changes
@@ -134,6 +146,13 @@ defmodule Mix.Tasks.Excessibility.Review do
       "#{length(changes)} view(s) changed — " <>
         "#{summary.block} block, #{summary.review} review, #{summary.auto} auto"
     )
+  end
+
+  defp print_warnings([]), do: :ok
+
+  defp print_warnings(warnings) do
+    Enum.each(warnings, &Mix.shell().info("WARNING: " <> &1))
+    Mix.shell().info("")
   end
 
   defp print_behavioral([]), do: :ok

--- a/lib/telemetry_capture.ex
+++ b/lib/telemetry_capture.ex
@@ -164,6 +164,10 @@ defmodule Excessibility.TelemetryCapture do
   Note: HTML snapshot files are NOT generated from telemetry capture.
   For real accessibility testing, use `html_snapshot(view)` in your tests
   to capture actual rendered HTML.
+
+  Runs in the `on_exit` installed by `use Excessibility`, so a failure
+  here is logged rather than raised — instrumentation must not fail the
+  test it observes.
   """
   def write_snapshots(test_name) do
     snapshots = get_snapshots()
@@ -187,6 +191,13 @@ defmodule Excessibility.TelemetryCapture do
 
       IO.puts("📊 Excessibility: Wrote timeline.json with #{length(snapshots)} events")
     end
+  rescue
+    error ->
+      Logger.warning(
+        "Excessibility: Failed to write timeline for #{inspect(test_name)}: #{Exception.format(:error, error, __STACKTRACE__)}"
+      )
+
+      :ok
   end
 
   # Resolve which enrichers to run based on EXCESSIBILITY_ANALYZERS env var

--- a/lib/telemetry_capture/filter.ex
+++ b/lib/telemetry_capture/filter.ex
@@ -13,6 +13,21 @@ defmodule Excessibility.TelemetryCapture.Filter do
   - `__meta__` fields
   - `NotLoaded` associations
   """
+  # Matched by name, not by struct expansion — ecto is a test-only dep,
+  # so `%Ecto.Association.NotLoaded{}` must not be required at compile
+  # time (it would break `mix docs`/`:dev` compilation).
+  def filter_ecto_metadata(%module{}) when module == Ecto.Association.NotLoaded, do: nil
+
+  # Structs satisfy is_map/1 but are not Enumerable, so they must be
+  # converted before the reduce below (an Ecto schema in a list of
+  # assigns would otherwise crash the capture).
+  def filter_ecto_metadata(%_{} = struct) do
+    struct
+    |> Map.from_struct()
+    |> Map.delete(:__meta__)
+    |> filter_ecto_metadata()
+  end
+
   def filter_ecto_metadata(assigns) when is_map(assigns) do
     Enum.reduce(assigns, %{}, fn {key, value}, acc ->
       cond do
@@ -23,16 +38,6 @@ defmodule Excessibility.TelemetryCapture.Filter do
         true -> Map.put(acc, key, value)
       end
     end)
-
-    # Skip __meta__ fields
-
-    # Skip NotLoaded associations
-
-    # Recursively filter maps
-
-    # Recursively filter lists
-
-    # Keep everything else
   end
 
   def filter_ecto_metadata(value) when is_list(value) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Excessibility.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/lessthanseventy/excessibility"
-  @version "0.15.0"
+  @version "0.15.1"
 
   def project do
     [

--- a/test/mix/tasks/excessibility_compare_test.exs
+++ b/test/mix/tasks/excessibility_compare_test.exs
@@ -1,0 +1,77 @@
+defmodule Mix.Tasks.Excessibility.CompareTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.Excessibility.Compare, as: CompareTask
+
+  @output_dir Path.join(["test", "excessibility"])
+  @snapshot_dir Path.join(@output_dir, "html_snapshots")
+  @baseline_dir Path.join(@output_dir, "baseline")
+
+  setup do
+    File.rm_rf!(@snapshot_dir)
+    File.rm_rf!(@baseline_dir)
+    File.mkdir_p!(@snapshot_dir)
+    File.mkdir_p!(@baseline_dir)
+
+    on_exit(fn ->
+      File.rm_rf!(@snapshot_dir)
+      File.rm_rf!(@baseline_dir)
+    end)
+
+    :ok
+  end
+
+  defp write_pair(name, baseline_html, current_html) do
+    File.write!(Path.join(@baseline_dir, name), baseline_html)
+    File.write!(Path.join(@snapshot_dir, name), current_html)
+  end
+
+  defp temp_diff_files do
+    @snapshot_dir |> Path.join("*.{good,bad}.html") |> Path.wildcard()
+  end
+
+  test "reports when all snapshots match the baseline" do
+    write_pair("home.html", "<div>same</div>", "<div>same</div>")
+
+    output = capture_io(fn -> CompareTask.run([]) end)
+
+    assert output =~ "match baseline"
+  end
+
+  # Under capture_io stdin is not a TTY, which is exactly the CI/agent
+  # situation from issue #134: prompting would read :eof. The task must
+  # refuse with guidance instead of crashing in parse_choice/1 — and
+  # since it refuses before writing .good/.bad pairs, nothing leaks.
+  test "refuses to prompt when stdin is not interactive" do
+    write_pair("home.html", "<div>old</div>", "<div>new</div>")
+
+    assert_raise Mix.Error, ~r/--keep/, fn ->
+      capture_io(fn -> CompareTask.run([]) end)
+    end
+
+    assert temp_diff_files() == []
+    assert File.read!(Path.join(@baseline_dir, "home.html")) == "<div>old</div>"
+  end
+
+  test "--keep good keeps all baselines and cleans up temp files" do
+    write_pair("home.html", "<div>old</div>", "<div>new</div>")
+
+    output = capture_io(fn -> CompareTask.run(["--keep", "good"]) end)
+
+    assert output =~ "Kept baseline for home.html"
+    assert File.read!(Path.join(@baseline_dir, "home.html")) == "<div>old</div>"
+    assert temp_diff_files() == []
+  end
+
+  test "--keep bad accepts all new versions and cleans up temp files" do
+    write_pair("home.html", "<div>old</div>", "<div>new</div>")
+
+    output = capture_io(fn -> CompareTask.run(["--keep", "bad"]) end)
+
+    assert output =~ "Updated baseline for home.html"
+    assert File.read!(Path.join(@baseline_dir, "home.html")) == "<div>new</div>"
+    assert temp_diff_files() == []
+  end
+end

--- a/test/mix/tasks/excessibility_review_test.exs
+++ b/test/mix/tasks/excessibility_review_test.exs
@@ -2,6 +2,7 @@ defmodule Mix.Tasks.Excessibility.ReviewTest do
   use ExUnit.Case
 
   import ExUnit.CaptureIO
+  import Mox
 
   alias Mix.Tasks.Excessibility.Review, as: ReviewTask
 
@@ -146,5 +147,79 @@ defmodule Mix.Tasks.Excessibility.ReviewTest do
     output = capture_io(fn -> ReviewTask.run(["--timeline", timeline_path]) end)
 
     assert output =~ "orders.html"
+  end
+
+  describe "axe-core findings" do
+    setup :verify_on_exit!
+
+    setup do
+      Application.put_env(:excessibility, :scanner_mod, Excessibility.ScannerMock)
+      on_exit(fn -> Application.put_env(:excessibility, :scanner_mod, Excessibility.ScannerStub) end)
+      :ok
+    end
+
+    # The reproduction from issue #131: a visible button losing its text is
+    # a new `button-name` critical, which must put the view in :block and
+    # make the default --fail-on block exit non-zero.
+    test "blocks on a newly introduced critical axe violation" do
+      write_pair(
+        "offer_detail.html",
+        ~s(<button data-test-id="review-button">Review Order</button>),
+        ~s(<button data-test-id="review-button"> </button>)
+      )
+
+      expect(Excessibility.ScannerMock, :scan, 2, fn "file://" <> path, _opts ->
+        if File.read!(path) =~ "Review Order" do
+          {:ok, %{violations: []}}
+        else
+          {:ok,
+           %{
+             violations: [
+               %{
+                 id: "button-name",
+                 impact: :critical,
+                 description: "Ensures buttons have discernible text",
+                 help: "Buttons must have discernible text",
+                 help_url: "https://dequeuniversity.com/rules/axe/4.11/button-name",
+                 tags: ["wcag2a"],
+                 nodes: [%{target: ["button"], html: "<button> </button>", failure_summary: "Fix it"}]
+               }
+             ]
+           }}
+        end
+      end)
+
+      output =
+        capture_io(fn ->
+          assert catch_exit(ReviewTask.run([])) == {:shutdown, 1}
+        end)
+
+      assert output =~ "[BLOCK] offer_detail.html"
+      assert output =~ "button-name"
+      assert output =~ "1 block"
+    end
+
+    test "--no-axe skips the scanner entirely" do
+      write_pair("home.html", "<div>old</div>", "<div>new</div>")
+
+      # No ScannerMock expectations: any scan call would raise.
+      output = capture_io(fn -> ReviewTask.run(["--no-axe"]) end)
+
+      assert output =~ "home.html"
+    end
+
+    test "a scan failure prints a warning and reviews on the LiveView rules alone" do
+      write_pair("home.html", "<div>old</div>", "<div>new</div>")
+
+      expect(Excessibility.ScannerMock, :scan, 2, fn _url, _opts ->
+        {:error, {:playwright_error, "chromium not found"}}
+      end)
+
+      output = capture_io(fn -> ReviewTask.run([]) end)
+
+      assert output =~ "WARNING: axe scan failed"
+      assert output =~ "chromium not found"
+      assert output =~ "home.html"
+    end
   end
 end

--- a/test/review/axe_findings_test.exs
+++ b/test/review/axe_findings_test.exs
@@ -1,0 +1,118 @@
+defmodule Excessibility.Review.AxeFindingsTest do
+  # Not async: swaps the global :scanner_mod between the Mox mock and the
+  # default stub.
+  use ExUnit.Case
+
+  import Mox
+
+  alias Excessibility.Review
+
+  setup :verify_on_exit!
+
+  setup do
+    Application.put_env(:excessibility, :scanner_mod, Excessibility.ScannerMock)
+    on_exit(fn -> Application.put_env(:excessibility, :scanner_mod, Excessibility.ScannerStub) end)
+    :ok
+  end
+
+  @baseline ~s(<div><button data-test-id="review-button">Review Order</button></div>)
+  @current ~s(<div><button data-test-id="review-button"> </button></div>)
+
+  # Answers scans by reading the temp file the review wrote, so each side
+  # of the pair can get its own report regardless of scan order.
+  defp expect_scans(reports_by_marker) do
+    expect(Excessibility.ScannerMock, :scan, map_size(reports_by_marker), fn "file://" <> path, _opts ->
+      html = File.read!(path)
+
+      {_marker, report} =
+        Enum.find(reports_by_marker, fn {marker, _report} -> String.contains?(html, marker) end)
+
+      {:ok, report}
+    end)
+  end
+
+  defp button_name_violation(nodes) do
+    %{
+      id: "button-name",
+      impact: :critical,
+      description: "Ensures buttons have discernible text",
+      help: "Buttons must have discernible text",
+      help_url: "https://dequeuniversity.com/rules/axe/4.11/button-name",
+      tags: ["wcag2a"],
+      nodes: nodes
+    }
+  end
+
+  defp axe_node(target) do
+    %{target: [target], html: "<button> </button>", failure_summary: "Fix any of the following..."}
+  end
+
+  test "a newly introduced critical axe violation is :block" do
+    expect_scans(%{
+      "Review Order" => %{violations: []},
+      ~s(> </button>) => %{violations: [button_name_violation([axe_node("button")])]}
+    })
+
+    change = Review.review_pair("offer_detail.html", @baseline, @current)
+
+    assert Enum.any?(
+             change.findings,
+             &(&1.rule == "button-name" and &1.severity == :critical and &1.selector == "button")
+           )
+
+    assert change.tier == :block
+  end
+
+  test "a pre-existing axe violation is not re-flagged (finding-delta)" do
+    violation = [button_name_violation([axe_node("button")])]
+
+    expect_scans(%{
+      "Review Order" => %{violations: violation},
+      ~s(> </button>) => %{violations: violation}
+    })
+
+    change = Review.review_pair("offer_detail.html", @baseline, @current)
+
+    refute Enum.any?(change.findings, &(&1.rule == "button-name"))
+  end
+
+  test "a second node of a pre-existing violation counts as new (per-node delta)" do
+    expect_scans(%{
+      "Review Order" => %{violations: [button_name_violation([axe_node("button")])]},
+      ~s(> </button>) => %{violations: [button_name_violation([axe_node("button"), axe_node("button")])]}
+    })
+
+    change = Review.review_pair("offer_detail.html", @baseline, @current)
+
+    assert Enum.count(change.findings, &(&1.rule == "button-name")) == 1
+    assert change.tier == :block
+  end
+
+  test "a scan failure surfaces a report-level warning instead of findings" do
+    expect(Excessibility.ScannerMock, :scan, 2, fn _url, _opts ->
+      {:error, {:playwright_error, "chromium not found"}}
+    end)
+
+    report = Review.review_pairs([{"offer_detail.html", @baseline, @current}])
+
+    assert [warning] = report.warnings
+    assert warning =~ "axe scan failed"
+    assert warning =~ "chromium not found"
+
+    refute Enum.any?(Enum.flat_map(report.changes, & &1.findings), &(&1.rule == "button-name"))
+  end
+
+  test "axe: false skips scanning entirely" do
+    change = Review.review_pair("offer_detail.html", @baseline, @current, axe: false)
+
+    assert change.warnings == []
+    refute Enum.any?(change.findings, &(&1.rule == "button-name"))
+  end
+
+  test "identical snapshots are not scanned" do
+    change = Review.review_pair("offer_detail.html", @baseline, @baseline)
+
+    assert change.tier == :auto
+    assert change.warnings == []
+  end
+end

--- a/test/scanner_test.exs
+++ b/test/scanner_test.exs
@@ -3,10 +3,11 @@ defmodule Excessibility.ScannerTest do
 
   alias Excessibility.Scanner
 
+  @moduletag timeout: 60_000
+
   @tmp_dir System.tmp_dir!()
 
   describe "scan/2 — happy paths" do
-    @tag timeout: 60_000
     test "returns a report with violations for inaccessible HTML" do
       path =
         write_tmp_html("""
@@ -28,7 +29,6 @@ defmodule Excessibility.ScannerTest do
       assert is_list(violation.nodes)
     end
 
-    @tag timeout: 60_000
     test "returns an empty violation list for accessible HTML" do
       path =
         write_tmp_html("""
@@ -43,7 +43,6 @@ defmodule Excessibility.ScannerTest do
       refute Enum.any?(report.violations, &(&1.impact == :critical))
     end
 
-    @tag timeout: 60_000
     test "report shape includes all documented fields" do
       path =
         write_tmp_html("""
@@ -70,7 +69,6 @@ defmodule Excessibility.ScannerTest do
       assert report.warnings == []
     end
 
-    @tag timeout: 60_000
     test "captures screenshot when :screenshot option set" do
       html_path =
         write_tmp_html("""
@@ -90,7 +88,6 @@ defmodule Excessibility.ScannerTest do
       assert File.exists?(png_path)
     end
 
-    @tag timeout: 60_000
     test "applies linked CSS before analyzing so hidden content is excluded" do
       css_path = Path.join(@tmp_dir, "scanner_css_#{System.unique_integer([:positive])}.css")
       File.write!(css_path, ".modal { display: none; }")
@@ -118,7 +115,6 @@ defmodule Excessibility.ScannerTest do
       assert report.warnings == []
     end
 
-    @tag timeout: 60_000
     test "warns when a linked stylesheet is missing" do
       path =
         write_tmp_html("""
@@ -137,7 +133,6 @@ defmodule Excessibility.ScannerTest do
       assert warning =~ "/nonexistent/assets/app.css"
     end
 
-    @tag timeout: 60_000
     test "respects :disable_rules option" do
       path =
         write_tmp_html("""
@@ -154,7 +149,6 @@ defmodule Excessibility.ScannerTest do
   end
 
   describe "scan/2 — multiple viewports" do
-    @tag timeout: 60_000
     test "returns per-viewport results and actually applies each width" do
       # The media query hides the unlabeled input below 400px, so axe must
       # report the label violation at 1440px but not at 320px — proving the
@@ -184,7 +178,6 @@ defmodule Excessibility.ScannerTest do
       assert is_list(narrow.incomplete)
     end
 
-    @tag timeout: 60_000
     test "suffixes screenshots per viewport" do
       html_path =
         write_tmp_html("""
@@ -212,7 +205,6 @@ defmodule Excessibility.ScannerTest do
       assert File.exists?(narrow_png)
     end
 
-    @tag timeout: 60_000
     test "single :viewport keeps the flat report shape" do
       path =
         write_tmp_html("""
@@ -235,7 +227,6 @@ defmodule Excessibility.ScannerTest do
     # at either width, which is exactly why the check exists.
     @clipped_button ~s(<button style="position:absolute; left:250px; width:300px">Ship it</button>)
 
-    @tag timeout: 60_000
     test "flags interactive elements clipped at narrow widths, per viewport" do
       path =
         write_tmp_html("""
@@ -260,7 +251,6 @@ defmodule Excessibility.ScannerTest do
       assert narrow.clipping.page_overflow?
     end
 
-    @tag timeout: 60_000
     test "clipping is nil when not requested" do
       path =
         write_tmp_html("""
@@ -276,7 +266,6 @@ defmodule Excessibility.ScannerTest do
       assert narrow.clipping == nil
     end
 
-    @tag timeout: 60_000
     test "works in single-viewport mode and respects :clipping_ratio" do
       path =
         write_tmp_html("""
@@ -304,7 +293,6 @@ defmodule Excessibility.ScannerTest do
   end
 
   describe "scan/2 — playwright resolution" do
-    @tag timeout: 60_000
     test "honors the :playwright_path config override" do
       bundled = Path.expand("assets/node_modules/playwright", File.cwd!())
       Application.put_env(:excessibility, :playwright_path, bundled)
@@ -321,7 +309,6 @@ defmodule Excessibility.ScannerTest do
       assert {:ok, _report} = Scanner.scan("file://#{path}")
     end
 
-    @tag timeout: 60_000
     test "reports an actionable error when :playwright_path is invalid" do
       Application.put_env(:excessibility, :playwright_path, "/nonexistent/playwright")
       on_exit(fn -> Application.delete_env(:excessibility, :playwright_path) end)
@@ -353,7 +340,6 @@ defmodule Excessibility.ScannerTest do
       assert {:error, {:invalid_url, :unsupported_scheme}} = Scanner.scan("ftp://example.com/")
     end
 
-    @tag timeout: 60_000
     test "returns {:error, {:navigation_failed, _}} for nonexistent file" do
       assert {:error, {:navigation_failed, _msg}} = Scanner.scan("file:///nonexistent/path.html")
     end

--- a/test/scanner_test.exs
+++ b/test/scanner_test.exs
@@ -133,6 +133,37 @@ defmodule Excessibility.ScannerTest do
       assert warning =~ "/nonexistent/assets/app.css"
     end
 
+    test "does not warn 'failed to load' when the sheet loaded but a nested @import failed" do
+      # Chromium fires an error event on the <link> when a nested @import
+      # fails even though the sheet itself loaded and applied. That must
+      # not read as "the stylesheet doesn't exist" — only as degraded
+      # styling from the missing import.
+      css_path = Path.join(@tmp_dir, "excessibility_import_#{System.unique_integer([:positive])}.css")
+
+      File.write!(css_path, """
+      @import url("file:///nonexistent/excessibility/missing-import.css");
+      body { color: rgb(20, 20, 20); }
+      """)
+
+      path =
+        write_tmp_html("""
+        <html lang="en"><head><title>Test</title>
+        <link rel="stylesheet" href="file://#{css_path}">
+        </head>
+        <body><h1>Hello</h1></body></html>
+        """)
+
+      on_exit(fn ->
+        File.rm(path)
+        File.rm(css_path)
+      end)
+
+      {:ok, report} = Scanner.scan("file://#{path}")
+
+      refute Enum.any?(report.warnings, &(&1 =~ "stylesheet failed to load"))
+      assert Enum.any?(report.warnings, &(&1 =~ "stylesheet import failed" and &1 =~ "missing-import.css"))
+    end
+
     test "respects :disable_rules option" do
       path =
         write_tmp_html("""

--- a/test/scanner_test.exs
+++ b/test/scanner_test.exs
@@ -340,6 +340,40 @@ defmodule Excessibility.ScannerTest do
       assert {:ok, _report} = Scanner.scan("file://#{path}")
     end
 
+    test "honors the :node_modules_path config override for playwright and the axe wrapper" do
+      bundled = Path.expand("assets/node_modules", File.cwd!())
+      Application.put_env(:excessibility, :node_modules_path, bundled)
+      on_exit(fn -> Application.delete_env(:excessibility, :node_modules_path) end)
+
+      path =
+        write_tmp_html("""
+        <html lang="en"><head><title>Test</title></head>
+        <body><h1>Hello</h1></body></html>
+        """)
+
+      on_exit(fn -> File.rm(path) end)
+
+      assert {:ok, report} = Scanner.scan("file://#{path}")
+      assert report.engine.axe_version
+    end
+
+    test "reports an actionable error when :node_modules_path is invalid" do
+      Application.put_env(:excessibility, :node_modules_path, "/nonexistent/node_modules")
+      on_exit(fn -> Application.delete_env(:excessibility, :node_modules_path) end)
+
+      path =
+        write_tmp_html("""
+        <html lang="en"><head><title>Test</title></head>
+        <body><h1>Hello</h1></body></html>
+        """)
+
+      on_exit(fn -> File.rm(path) end)
+
+      assert {:error, {:playwright_error, message}} = Scanner.scan("file://#{path}", fallback: false)
+      assert message =~ "/nonexistent/node_modules"
+      assert message =~ "EXCESSIBILITY_NODE_MODULES_PATH"
+    end
+
     test "reports an actionable error when :playwright_path is invalid" do
       Application.put_env(:excessibility, :playwright_path, "/nonexistent/playwright")
       on_exit(fn -> Application.delete_env(:excessibility, :playwright_path) end)

--- a/test/snapshot_test.exs
+++ b/test/snapshot_test.exs
@@ -68,7 +68,7 @@ defmodule Excessibility.SnapshotTest do
   describe "screenshot failures" do
     setup do
       Application.put_env(:excessibility, :scanner_mod, Excessibility.ScannerMock)
-      on_exit(fn -> Application.delete_env(:excessibility, :scanner_mod) end)
+      on_exit(fn -> Application.put_env(:excessibility, :scanner_mod, Excessibility.ScannerStub) end)
     end
 
     test "a failed screenshot logs the reason and keeps the HTML snapshot" do

--- a/test/support/scanner_stub.ex
+++ b/test/support/scanner_stub.ex
@@ -1,0 +1,11 @@
+defmodule Excessibility.ScannerStub do
+  @moduledoc """
+  Default `:scanner_mod` for the test suite: reports no violations without
+  launching a browser. Tests that assert on axe behavior swap in
+  `Excessibility.ScannerMock` (Mox) and restore this stub afterwards.
+  """
+  @behaviour Excessibility.ScannerBehaviour
+
+  @impl true
+  def scan(_url, _opts), do: {:ok, %{violations: []}}
+end

--- a/test/telemetry_capture/filter_test.exs
+++ b/test/telemetry_capture/filter_test.exs
@@ -14,6 +14,12 @@ defmodule Excessibility.TelemetryCapture.FilterTest do
     defstruct [:value, :handler]
   end
 
+  # Shaped like an Ecto schema struct: carries __meta__ and is not Enumerable
+  defmodule Offering do
+    @moduledoc false
+    defstruct [:id, :name, :__meta__]
+  end
+
   describe "filter_ecto_metadata/1" do
     test "removes __meta__ fields from maps" do
       assigns = %{
@@ -74,6 +80,46 @@ defmodule Excessibility.TelemetryCapture.FilterTest do
       result = Filter.filter_ecto_metadata(assigns)
 
       assert result == assigns
+    end
+
+    test "handles a list of Ecto structs without raising" do
+      assigns = %{items: [%Offering{id: 1, name: "A", __meta__: "remove"}]}
+
+      result = Filter.filter_ecto_metadata(assigns)
+
+      assert [item] = result.items
+      assert item.id == 1
+      assert item.name == "A"
+      refute Map.has_key?(item, :__meta__)
+    end
+
+    test "handles a list of Ecto structs nested inside a map" do
+      assigns = %{wrap: %{items: [%Offering{id: 2, name: "B", __meta__: "remove"}]}}
+
+      assert [item] = Filter.filter_ecto_metadata(assigns).wrap.items
+      assert item.id == 2
+      refute Map.has_key?(item, :__meta__)
+    end
+
+    test "handles a struct passed directly" do
+      result = Filter.filter_ecto_metadata(%Offering{id: 3, name: "C", __meta__: "remove"})
+
+      assert result.id == 3
+      refute Map.has_key?(result, :__meta__)
+    end
+
+    test "drops NotLoaded associations inside struct list elements" do
+      not_loaded = %Ecto.Association.NotLoaded{__field__: :posts, __owner__: User}
+      assigns = %{items: [%{id: 1, posts: not_loaded}]}
+
+      assert [item] = Filter.filter_ecto_metadata(assigns).items
+      refute Map.has_key?(item, :posts)
+    end
+
+    test "handles lists of scalars" do
+      assigns = %{ids: [1, 2, 3], tags: ["a"]}
+
+      assert Filter.filter_ecto_metadata(assigns) == assigns
     end
   end
 

--- a/test/telemetry_capture_integration_test.exs
+++ b/test/telemetry_capture_integration_test.exs
@@ -1,7 +1,15 @@
 defmodule Excessibility.TelemetryCaptureIntegrationTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureLog
+
   alias Excessibility.TelemetryCapture
+
+  # Shaped like an Ecto schema struct: carries __meta__ and is not Enumerable
+  defmodule FakeSchema do
+    @moduledoc false
+    defstruct [:id, :name, :__meta__]
+  end
 
   setup do
     # Clean up any existing snapshots
@@ -64,6 +72,61 @@ defmodule Excessibility.TelemetryCaptureIntegrationTest do
     # Cleanup
     TelemetryCapture.detach()
     File.rm_rf!("test/excessibility")
+  end
+
+  test "write_snapshots handles a list of Ecto structs in assigns" do
+    TelemetryCapture.attach()
+
+    TelemetryCapture.handle_event(
+      [:phoenix, :live_view, :mount, :stop],
+      %{duration: 100},
+      %{
+        socket: %{
+          assigns: %{product_offerings: [%FakeSchema{id: 1, name: "A", __meta__: :loaded}]},
+          view: MyApp.Live
+        }
+      },
+      nil
+    )
+
+    TelemetryCapture.write_snapshots("struct_list_test")
+
+    timeline_path = "test/excessibility/timeline.json"
+    assert File.exists?(timeline_path)
+    assert %{"test" => "struct_list_test"} = timeline_path |> File.read!() |> Jason.decode!()
+
+    TelemetryCapture.detach()
+    File.rm_rf!("test/excessibility")
+  end
+
+  test "write_snapshots logs instead of raising when the timeline cannot be written" do
+    TelemetryCapture.attach()
+
+    TelemetryCapture.handle_event(
+      [:phoenix, :live_view, :mount, :stop],
+      %{duration: 100},
+      %{socket: %{assigns: %{user_id: 1}, view: MyApp.Live}},
+      nil
+    )
+
+    # A regular file as the output path's parent makes mkdir_p! fail
+    blocker = Path.join(System.tmp_dir!(), "excessibility_blocker_#{System.unique_integer([:positive])}")
+    File.write!(blocker, "not a directory")
+    Application.put_env(:excessibility, :excessibility_output_path, Path.join(blocker, "out"))
+
+    on_exit(fn ->
+      Application.delete_env(:excessibility, :excessibility_output_path)
+      File.rm(blocker)
+    end)
+
+    log =
+      capture_log(fn ->
+        TelemetryCapture.write_snapshots("resilience_test")
+      end)
+
+    assert log =~ "Failed to write timeline"
+
+    TelemetryCapture.detach()
   end
 
   test "write_snapshots generates timeline.json" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,6 +9,7 @@ Application.put_env(:excessibility, Excessibility.TestEndpoint,
 
 # Compile test support files
 Code.require_file("test/support/test_endpoint.ex", File.cwd!())
+Code.require_file("test/support/scanner_stub.ex", File.cwd!())
 
 ExUnit.start()
 
@@ -20,6 +21,9 @@ Mox.defmock(Excessibility.ScannerMock, for: Excessibility.ScannerBehaviour)
 Application.put_env(:excessibility, :system_mod, Excessibility.SystemMock)
 Application.put_env(:excessibility, :live_view_mod, Excessibility.LiveViewMock)
 Application.put_env(:excessibility, :browser_mod, Excessibility.BrowserMock)
+# Reviews scan snapshots through :scanner_mod; default to a no-violation
+# stub so unit tests never launch a browser.
+Application.put_env(:excessibility, :scanner_mod, Excessibility.ScannerStub)
 
 # Configure test endpoint for HTML attribute extraction tests
 Application.put_env(:excessibility, :endpoint, Excessibility.TestEndpoint)


### PR DESCRIPTION
Fixes the five open issues in one patch release.

## Fixed

- **#131 — `excessibility.review` ignores axe-core findings.** The review now scans both sides of every changed snapshot pair through the configured `:scanner_mod` (temp file + `file://`) and folds axe violations into the existing finding-delta — one finding per offending node, fingerprinted `{id, target}`, so the counted-delta semantics from #130 apply to axe too. A newly introduced `button-name` critical is now `:block` and `--fail-on block` exits non-zero. `--no-axe` (API: `axe: false`) opts out; a failed scan degrades to the LiveView rules with a report-level warning instead of dying. Closes #131.
- **#132 — false `stylesheet failed to load` on nested `@import` failure.** The warning is now gated on `link.sheet` (null exactly when the sheet did not load or parse); the error event only feeds the wait predicate. Failing imports surface separately as `stylesheet import failed: <url> — text metrics may differ from production`, collected via Playwright `requestfailed`. Verified against the bundled Playwright with the exact repro from the issue. Closes #132.
- **#133 — telemetry capture crashes on lists of Ecto structs.** `filter_ecto_metadata/1` gained struct head clauses (`Map.from_struct` + drop `__meta__`; `NotLoaded` → `nil`) so list elements no longer get `Enum.reduce`d. Independently, `write_snapshots/1` rescues and logs, so a timeline failure can no longer fail the test it observes (same shape as the #126 screenshot fix). Also removed the stale duplicate comments. Closes #133.
- **#134 — `excessibility.compare` crashes on `:eof` and leaks temp files.** The task refuses up front when stdin isn't a TTY and no `--keep` was given (actionable `Mix.raise`, so no browser windows and no temp files either). Mid-run `:eof`/`{:error, _}` now keeps the baseline (fail-safe — flipped from the old accept-the-new-version default), and diff resolution is wrapped in `try/after cleanup_diff_files()`. Closes #134.

## Added

- **#135 — `node_modules_path` config.** `resolve-playwright.js` grew a generalized `resolveModule` (override → bundled → ambient) and `@axe-core/playwright` resolves through it in both runner scripts, so a host `node_modules` providing both packages removes the mandatory `npm install` inside `deps/excessibility/assets`. A configured-but-wrong path hard-fails with an actionable message rather than silently switching axe versions; the host-pins-axe-version caveat is documented in the scanner moduledoc and README. Closes #135.

## Notes

- Unit tests default `:scanner_mod` to a new no-op `Excessibility.ScannerStub` so nothing launches Chromium outside `scanner_test.exs`; the axe-delta paths are covered with Mox (`test/review/axe_findings_test.exs`, new mix-task tests including the #131 repro end-to-end).
- Reviews now cost one browser scan per **changed** pair; byte-identical snapshots short-circuit before scanning.
- `mix test` 772/772 green, `mix format --check-formatted` clean, `mix credo --strict` clean. Version bumped to 0.15.1 with CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)