### PR TITLE
fix: report missing stylesheets as 'failed to load' again; release v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.2] - 2026-08-05
+
+### Fixed
+- **A genuinely missing stylesheet is again reported as `stylesheet failed to load`** ([#137](https://github.com/lessthanseventy/excessibility/issues/137)). The `link.sheet` gate from 0.15.1 assumed a failed sheet leaves `link.sheet` null, but under `file://` Chromium attaches a non-null empty `CSSStyleSheet` to a `<link>` whose file is missing — so the severe warning never fired and the run was understated as `stylesheet import failed`. Failures are now classified by the network signal: a failed stylesheet request matching a `link[rel~="stylesheet"]` href is that link failing (`stylesheet failed to load: … — contrast/layout findings are invalid until it exists`); any other failed stylesheet request is a nested `@import` (`stylesheet import failed: … — text metrics may differ from production`). The null-sheet list is still unioned in for sheets that downloaded but failed to parse, and the 0.15.1 fix for [#132](https://github.com/lessthanseventy/excessibility/issues/132) (loaded sheet with a failing `@import` must not warn `failed to load`) is regression-tested alongside.
+
 ## [0.15.1] - 2026-08-05
 
 ### Fixed

--- a/assets/axe-runner.js
+++ b/assets/axe-runner.js
@@ -123,7 +123,7 @@ async function installStylesheetTracker(page) {
   // The flag only feeds the wait predicate below. Chromium also fires this
   // error event when the sheet loaded fine but a nested @import failed, so
   // it cannot be used to decide whether the stylesheet itself is missing —
-  // link.sheet is the authoritative signal for that.
+  // the failed network requests are the authoritative signal for that.
   await page.addInitScript(() => {
     window.addEventListener(
       "error",
@@ -165,26 +165,40 @@ async function waitForStylesheets(page, warnings, failedStylesheetRequests, maxW
       );
     });
 
-  // link.sheet is null exactly when the stylesheet did not load or parse,
-  // so a genuinely missing file warns while a loaded sheet whose nested
-  // @import failed does not.
-  const failed = await page
-    .evaluate(() =>
-      [...document.querySelectorAll('link[rel~="stylesheet"]')].filter((l) => !l.sheet).map((l) => l.href),
-    )
-    .catch(() => []);
-  for (const href of failed) {
-    warnings.push(`stylesheet failed to load: ${href} — contrast/layout findings are invalid until it exists`);
+  // link.sheet cannot classify failures: under file:// Chromium attaches a
+  // non-null empty CSSStyleSheet to a <link> whose file is missing. The
+  // network view discriminates instead — a failed stylesheet request whose
+  // URL matches a <link> href is that link failing; any other failed
+  // stylesheet request is a nested @import. The null-sheet list is still
+  // unioned in for sheets that downloaded but failed to parse, where no
+  // request fails.
+  const { linkHrefs, nullSheetHrefs } = await page
+    .evaluate(() => {
+      const links = [...document.querySelectorAll('link[rel~="stylesheet"]')];
+      return {
+        linkHrefs: links.map((l) => l.href),
+        nullSheetHrefs: links.filter((l) => !l.sheet).map((l) => l.href),
+      };
+    })
+    .catch(() => ({ linkHrefs: [], nullSheetHrefs: [] }));
+
+  const linkHrefSet = new Set(linkHrefs);
+  const failedLinks = new Set(nullSheetHrefs);
+  const failedImports = new Set();
+  for (const url of new Set(failedStylesheetRequests)) {
+    if (linkHrefSet.has(url)) {
+      failedLinks.add(url);
+    } else {
+      failedImports.add(url);
+    }
   }
 
-  // A failed stylesheet request that isn't one of the missing <link>s is a
-  // nested @import (e.g. a remote font stylesheet blocked from file://).
+  for (const href of failedLinks) {
+    warnings.push(`stylesheet failed to load: ${href} — contrast/layout findings are invalid until it exists`);
+  }
   // Styling is degraded, not absent — fallback fonts change text metrics.
-  const failedSet = new Set(failed);
-  for (const url of new Set(failedStylesheetRequests)) {
-    if (!failedSet.has(url)) {
-      warnings.push(`stylesheet import failed: ${url} — text metrics may differ from production`);
-    }
+  for (const url of failedImports) {
+    warnings.push(`stylesheet import failed: ${url} — text metrics may differ from production`);
   }
 
   await page.evaluate(() => document.fonts && document.fonts.ready).catch(() => {});

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Excessibility.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/lessthanseventy/excessibility"
-  @version "0.15.1"
+  @version "0.15.2"
 
   def project do
     [

--- a/test/scanner_test.exs
+++ b/test/scanner_test.exs
@@ -115,7 +115,10 @@ defmodule Excessibility.ScannerTest do
       assert report.warnings == []
     end
 
-    test "warns when a linked stylesheet is missing" do
+    test "warns 'failed to load' when a linked stylesheet is missing" do
+      # Under file:// Chromium attaches a non-null empty CSSStyleSheet to a
+      # <link> whose file doesn't exist, so this must classify via the
+      # failed network request, not link.sheet (issue #137).
       path =
         write_tmp_html("""
         <html lang="en"><head><title>Test</title>
@@ -128,9 +131,12 @@ defmodule Excessibility.ScannerTest do
 
       {:ok, report} = Scanner.scan("file://#{path}")
 
-      assert [warning | _] = report.warnings
-      assert warning =~ "stylesheet"
-      assert warning =~ "/nonexistent/assets/app.css"
+      assert Enum.any?(
+               report.warnings,
+               &(&1 =~ "stylesheet failed to load" and &1 =~ "/nonexistent/assets/app.css")
+             )
+
+      refute Enum.any?(report.warnings, &(&1 =~ "stylesheet import failed"))
     end
 
     test "does not warn 'failed to load' when the sheet loaded but a nested @import failed" do


### PR DESCRIPTION
## Summary

Fixes #137 — follow-up to #132/v0.15.1.

The `!l.sheet` gate introduced in 0.15.1 assumed a stylesheet that fails to load leaves `link.sheet` null. That holds over http, but under `file://` Chromium attaches a **non-null, empty** `CSSStyleSheet` to a `<link>` whose file is missing — so the severe `stylesheet failed to load: … — contrast/layout findings are invalid until it exists` warning never fired, and a genuinely missing stylesheet was understated as the mild `stylesheet import failed`.

## Fix

Classify with the network signal already collected in `axe-runner.js` instead of the DOM:

- A failed stylesheet request whose URL matches a `link[rel~="stylesheet"]` href → that link failing → `stylesheet failed to load`.
- Any other failed stylesheet request → nested `@import` → `stylesheet import failed`.
- The null-sheet list is still unioned in, catching a sheet that downloaded but failed to parse (where no request fails).

The wait predicate (`l.sheet || l.__excessibilityFailed`) is unchanged — only classification moved to the network view.

## Tests

Both fixtures from the issue are now asserted, so the two cases stay distinguishable:

1. `<link>` to an absent file → expects `failed to load`, refutes `import failed` (this bug; failed before the fix with exactly the misclassified warning).
2. Present sheet with an unfetchable `@import` → expects `import failed`, refutes `failed to load` (the 0.15.0 false positive from #132; still passes).

`mix test`: 772 tests, 0 failures. `mix format --check-formatted` and `mix credo --strict` clean.

## Release

Bumps version to 0.15.2 with a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)