### PR TITLE
fix: eliminate review false positives across independent runs; release v0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.15.3] - 2026-08-05
 
 ### Changed
 - **Content-change findings are opt-in for reviews** ([#139](https://github.com/lessthanseventy/excessibility/issues/139)). `mix excessibility.review` compares a baseline and a current snapshot that normally come from two independent `mix test` runs, where the rendered text differs wherever fixtures do (record ids, generated names) — on one real PR that produced 319 false `content_change_without_live_region` findings. The rule is only meaningful when both sides rendered the same fixture data, so `Excessibility.Review` now folds it in only with `content_diff: true` (`mix excessibility.review --content-diff`). Within-run sequence scanning (`SnapshotDiff.scan_sequence/2`, used by `mix excessibility`) and the MCP `diff_snapshots` tool (before/after around a single edit, same fixtures) keep the rule unconditionally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Content-change findings are opt-in for reviews** ([#139](https://github.com/lessthanseventy/excessibility/issues/139)). `mix excessibility.review` compares a baseline and a current snapshot that normally come from two independent `mix test` runs, where the rendered text differs wherever fixtures do (record ids, generated names) — on one real PR that produced 319 false `content_change_without_live_region` findings. The rule is only meaningful when both sides rendered the same fixture data, so `Excessibility.Review` now folds it in only with `content_diff: true` (`mix excessibility.review --content-diff`). Within-run sequence scanning (`SnapshotDiff.scan_sequence/2`, used by `mix excessibility`) and the MCP `diff_snapshots` tool (before/after around a single edit, same fixtures) keep the rule unconditionally.
+
+
 ## [0.15.2] - 2026-08-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Content-change findings are opt-in for reviews** ([#139](https://github.com/lessthanseventy/excessibility/issues/139)). `mix excessibility.review` compares a baseline and a current snapshot that normally come from two independent `mix test` runs, where the rendered text differs wherever fixtures do (record ids, generated names) — on one real PR that produced 319 false `content_change_without_live_region` findings. The rule is only meaningful when both sides rendered the same fixture data, so `Excessibility.Review` now folds it in only with `content_diff: true` (`mix excessibility.review --content-diff`). Within-run sequence scanning (`SnapshotDiff.scan_sequence/2`, used by `mix excessibility`) and the MCP `diff_snapshots` tool (before/after around a single edit, same fixtures) keep the rule unconditionally.
 
+### Fixed
+- **Finding fingerprints no longer depend on database ids** ([#140](https://github.com/lessthanseventy/excessibility/issues/140)). Reviews identify pre-existing findings by `{rule, selector}`, and selectors are built from DOM ids — which Phoenix idiomatically derives from record ids (`id={"row-#{@row.id}"}`). Fixture ids shift between the baseline run and the current run, so a pre-existing finding could resurface under a new id (`#section-2` → `#section-7`) and be reported as a newly introduced `:block`. Digit runs in the selector are now collapsed for fingerprinting (`#section-2` and `#section-7` both compare as `#section-N`); the raw selector is unchanged in the reported finding.
+
 
 ## [0.15.2] - 2026-08-05
 

--- a/lib/excessibility/mcp/tools/diff_snapshots.ex
+++ b/lib/excessibility/mcp/tools/diff_snapshots.ex
@@ -41,7 +41,10 @@ defmodule Excessibility.MCP.Tools.DiffSnapshots do
 
   @impl true
   def execute(%{"before" => before, "after" => current} = args, _opts) when is_binary(before) and is_binary(current) do
-    change = Review.review_pair(Map.get(args, "view", "diff"), before, current)
+    # Before/after here are the same view re-rendered around the agent's own
+    # edit, so both sides share fixture data and the content diff is sound —
+    # unlike `mix excessibility.review`, where it is opt-in.
+    change = Review.review_pair(Map.get(args, "view", "diff"), before, current, content_diff: true)
 
     {:ok,
      %{

--- a/lib/excessibility/review.ex
+++ b/lib/excessibility/review.ex
@@ -221,7 +221,12 @@ defmodule Excessibility.Review do
     |> Map.fetch!(:findings)
   end
 
-  defp fingerprint(%{rule: rule, selector: selector}), do: {rule, selector}
+  # Selectors embed DOM ids, and Phoenix idiomatically derives those from
+  # record ids (`id={"row-#{@row.id}"}`) whose values shift between the
+  # baseline run and the current run (issue #140), so digit runs are
+  # collapsed before comparing. The raw selector stays on the finding for
+  # display.
+  defp fingerprint(%{rule: rule, selector: selector}), do: {rule, String.replace(selector, ~r/\d+/, "N")}
 
   # ── axe-core findings ──────────────────────────────────────────────
 

--- a/lib/excessibility/review.ex
+++ b/lib/excessibility/review.ex
@@ -10,9 +10,15 @@ defmodule Excessibility.Review do
     * the rendered regions that changed (via `Excessibility.SnapshotDiff`)
     * the accessibility findings this change **newly introduced** —
       axe-core violations and `Excessibility.LiveViewRules` violations
-      present now but not in the baseline (a finding-delta), plus content
-      that changed without an `aria-live` announcement
+      present now but not in the baseline (a finding-delta)
     * a risk **tier** — `:auto`, `:review`, or `:block`
+
+  With `content_diff: true`, content that changed without an `aria-live`
+  announcement is also flagged. That signal compares rendered text, so it
+  is only meaningful when the baseline and current snapshots rendered the
+  **same fixture data** — with the usual CI shape (baseline and current
+  from two independent `mix test` runs) it mostly reports fixture drift,
+  which is why it is off by default.
 
   axe-core runs through the configured `:scanner_mod` (a browser scan of
   each side of the pair); disable it with `axe: false`. When a scan fails
@@ -130,7 +136,7 @@ defmodule Excessibility.Review do
     {axe_pair, warnings} = axe_findings_pair(baseline_html, current_html, opts)
 
     findings =
-      SnapshotDiff.live_region_findings(baseline_html, current_html, opts) ++
+      content_change_findings(baseline_html, current_html, opts) ++
         new_rule_findings(baseline_html, current_html, axe_pair, opts)
 
     behavioral =
@@ -168,6 +174,18 @@ defmodule Excessibility.Review do
       severities != [] -> :review
       true -> :auto
     end
+  end
+
+  # `content_change_without_live_region` compares rendered text, so it only
+  # means something when both sides rendered the same fixture data. The
+  # baseline and current snapshots normally come from two independent
+  # `mix test` runs whose fixtures differ (issue #139), so it is opt-in here
+  # — unlike `SnapshotDiff.scan_sequence/2`, which diffs consecutive
+  # snapshots within one run and keeps it unconditionally.
+  defp content_change_findings(baseline_html, current_html, opts) do
+    if Keyword.get(opts, :content_diff, false),
+      do: SnapshotDiff.live_region_findings(baseline_html, current_html, opts),
+      else: []
   end
 
   # Rule violations (LiveView rules + axe) present in the current snapshot

--- a/lib/mix/tasks/excessibility_review.ex
+++ b/lib/mix/tasks/excessibility_review.ex
@@ -10,8 +10,7 @@ defmodule Mix.Tasks.Excessibility.Review do
 
     * `block`  — a new critical/serious issue (e.g. a keyboard-inaccessible
       control introduced by this change)
-    * `review` — a new moderate/minor issue, or content that changed
-      without an `aria-live` announcement; worth a human glance
+    * `review` — a new moderate/minor issue; worth a human glance
     * `auto`   — rendering changed but introduced no accessibility issues
 
   ## Usage
@@ -31,6 +30,13 @@ defmodule Mix.Tasks.Excessibility.Review do
       # Skip the axe-core browser scans and review on the LiveView rules only
       mix excessibility.review --no-axe
 
+      # Also flag content that changed without an aria-live announcement.
+      # Only turn this on when both sides rendered the SAME fixture data:
+      # baseline and current usually come from two independent `mix test`
+      # runs, and with non-deterministic fixtures the text delta reports
+      # fixture drift, not accessibility regressions.
+      mix excessibility.review --content-diff
+
   New findings are the union of axe-core violations (scanned per snapshot
   pair through Playwright) and the LiveView rules. If the axe scan fails
   (e.g. Playwright isn't installed), the review degrades to the LiveView
@@ -48,7 +54,9 @@ defmodule Mix.Tasks.Excessibility.Review do
   @impl Mix.Task
   def run(args) do
     {opts, _argv, _invalid} =
-      OptionParser.parse(args, strict: [fail_on: :string, judge: :boolean, timeline: :string, axe: :boolean])
+      OptionParser.parse(args,
+        strict: [fail_on: :string, judge: :boolean, timeline: :string, axe: :boolean, content_diff: :boolean]
+      )
 
     fail_on = parse_fail_on(opts[:fail_on])
 
@@ -65,7 +73,7 @@ defmodule Mix.Tasks.Excessibility.Review do
   # behavioral findings — N+1 queries, dead state, render thrash — inform the
   # review alongside the DOM diff.
   defp review_opts(opts) do
-    base = [axe: Keyword.get(opts, :axe, true)]
+    base = [axe: Keyword.get(opts, :axe, true), content_diff: Keyword.get(opts, :content_diff, false)]
 
     case opts[:timeline] do
       nil -> base

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Excessibility.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/lessthanseventy/excessibility"
-  @version "0.15.2"
+  @version "0.15.3"
 
   def project do
     [

--- a/test/mix/tasks/excessibility_review_test.exs
+++ b/test/mix/tasks/excessibility_review_test.exs
@@ -53,10 +53,20 @@ defmodule Mix.Tasks.Excessibility.ReviewTest do
     assert output =~ "1 block"
   end
 
-  test "a content change without aria-live is :review (does not block by default)" do
+  test "a content change without aria-live is :auto by default (independent-run fixtures)" do
     write_pair("orders.html", @table_two, @table_one)
 
     output = capture_io(fn -> ReviewTask.run([]) end)
+
+    assert output =~ "[AUTO] orders.html"
+    refute output =~ "content_change_without_live_region"
+    assert output =~ "1 auto"
+  end
+
+  test "--content-diff flags a content change without aria-live as :review" do
+    write_pair("orders.html", @table_two, @table_one)
+
+    output = capture_io(fn -> ReviewTask.run(["--content-diff"]) end)
 
     assert output =~ "[REVIEW] orders.html"
     assert output =~ "content_change_without_live_region"
@@ -67,7 +77,7 @@ defmodule Mix.Tasks.Excessibility.ReviewTest do
     write_pair("orders.html", @table_two, @table_one)
 
     capture_io(fn ->
-      assert catch_exit(ReviewTask.run(["--fail-on", "review"])) == {:shutdown, 1}
+      assert catch_exit(ReviewTask.run(["--content-diff", "--fail-on", "review"])) == {:shutdown, 1}
     end)
   end
 

--- a/test/review_test.exs
+++ b/test/review_test.exs
@@ -30,8 +30,19 @@ defmodule Excessibility.ReviewTest do
       assert change.tier == :auto
     end
 
-    test "content changed outside a live region is :review with the changed region" do
+    test "content changed outside a live region is not flagged by default (fixtures differ across runs)" do
+      # The baseline and current snapshots come from independent `mix test`
+      # runs, so text deltas usually mean different fixture data, not a
+      # template change — see issue #139. The region is still reported.
       change = Review.review_pair("orders", @table_two, @table_one)
+
+      assert change.region_count == 1
+      assert change.findings == []
+      assert change.tier == :auto
+    end
+
+    test "content changed outside a live region is :review with content_diff: true" do
+      change = Review.review_pair("orders", @table_two, @table_one, content_diff: true)
 
       assert change.region_count == 1
       assert Enum.any?(change.findings, &(&1.rule == :content_change_without_live_region))
@@ -94,7 +105,7 @@ defmodule Excessibility.ReviewTest do
         {"editor", "<div>Save</div>", ~s(<div phx-click="save">Save</div>)}
       ]
 
-      report = Review.review_pairs(pairs)
+      report = Review.review_pairs(pairs, content_diff: true)
 
       views = Enum.map(report.changes, & &1.view)
       refute "unchanged" in views

--- a/test/review_test.exs
+++ b/test/review_test.exs
@@ -72,6 +72,30 @@ defmodule Excessibility.ReviewTest do
       assert change.tier == :block
     end
 
+    test "a pre-existing violation whose selector differs only by an embedded record id is not new" do
+      # Phoenix idiomatically derives DOM ids from record ids
+      # (`id={"row-#{@row.id}"}`), and fixture ids shift between the baseline
+      # run and the current run — see issue #140. Same rule, same markup
+      # pattern, different trailing id must not read as a new finding.
+      baseline = ~s(<div><span id="row-2" phx-click="a">one</span></div>)
+      current = ~s(<div><span id="row-7" phx-click="a">one</span></div>)
+
+      change = Review.review_pair("list", baseline, current)
+
+      assert change.findings == []
+      assert change.tier == :auto
+    end
+
+    test "an additional violation on an id-shifted sibling still counts as new" do
+      baseline = ~s(<div><span id="row-2" phx-click="a">one</span></div>)
+      current = ~s(<div><span id="row-2" phx-click="a">one</span><span id="row-7" phx-click="b">two</span></div>)
+
+      change = Review.review_pair("list", baseline, current)
+
+      assert Enum.count(change.findings, &(&1.rule == :phx_click_on_non_interactive)) == 1
+      assert change.tier == :block
+    end
+
     test "a pre-existing rule violation is not counted as new (finding-delta)" do
       # The phx-click violation exists in BOTH snapshots; only the text inside
       # a live region changed, so there is nothing newly wrong.


### PR DESCRIPTION
## Summary

Fixes #139 and #140 — both found replaying a real merged PR through `mix excessibility.review` 0.15.2, where the baseline and current snapshots come from two independent `mix test` runs (the normal CI shape).

## #139 — content-change findings are now opt-in

`content_change_without_live_region` compares rendered text, so it is only meaningful when both sides rendered the same fixture data. Across independent runs the text differs wherever fixtures do (record ids, generated names), which produced 319 false findings on one PR. `Excessibility.Review` now folds the rule in only with `content_diff: true` (`mix excessibility.review --content-diff`), documented as requiring deterministic fixtures.

Unchanged, because their two sides do share fixtures:
- `SnapshotDiff.scan_sequence/2` (consecutive snapshots within one run, used by `mix excessibility`)
- the MCP `diff_snapshots` tool (before/after around a single edit), which now passes `content_diff: true` explicitly

## #140 — fingerprints no longer depend on database ids

Findings are identified by `{rule, selector}`, and selectors embed DOM ids that Phoenix idiomatically derives from record ids (`id={"row-#{@row.id}"}`). Fixture ids shift between runs, so a pre-existing finding resurfaced under a new id (`#section-2` → `#section-7`) and was reported as a newly introduced `:block`. Digit runs in the selector are now collapsed for fingerprinting (both compare as `#section-N`); the raw selector is unchanged in the reported finding for display.

## Release

Bumps to v0.15.3 per the usual flow.

## Verification

- `mix test` — 776 tests, 0 failures
- `mix format --check-formatted` and `MIX_ENV=test mix credo --strict` clean
- New regression tests: default review is `:auto` with no content findings on a text-only delta; `--content-diff` restores the old behavior; an id-shifted pre-existing violation is not new; an additional violation on an id-shifted sibling still is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)