### PR TITLE
Fix behavioral false positives on healthy timelines + JSON review output (#142, #143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-08-06
+
+### Added
+- **`mix excessibility.review --format json`** (`--json` alias) ([#143](https://github.com/lessthanseventy/excessibility/issues/143)). Emits the review as a single JSON object on stdout — `excessibility_version`, `summary`, `warnings`, `behavioral`, and per-change `view`/`tier`/`region_count`/`findings` — so CI and PR bots consume a stable API instead of scraping the printed report. Every finding carries a `source` (`live_view_rules` / `axe` / `telemetry`), which makes "axe degraded, so these results are rules-only" expressible without matching prose. The human report stays the default; the stale-snapshot notice moves into the `warnings` array so stdout is only the JSON object.
+- **`mix excessibility.review --fail-on-behavioral`** ([#142](https://github.com/lessthanseventy/excessibility/issues/142)). Opt in to failing the build on a serious behavioral (telemetry) finding.
+
+### Changed
+- **Behavioral findings are advisory by default** ([#142](https://github.com/lessthanseventy/excessibility/issues/142)). A serious behavioral finding (memory bloat, render thrash, etc.) no longer fails `mix excessibility.review`. Unlike accessibility findings — a true delta against the baseline — behavioral findings are absolute measurements of a single run, so they are advisory unless you opt in with `--fail-on-behavioral`. Accessibility tiers still gate the build via `--fail-on` (default `block`).
+
+### Fixed
+- **Behavioral analyzers no longer compare across different LiveViews** ([#142](https://github.com/lessthanseventy/excessibility/issues/142)). A journey test drives several LiveViews, so the timeline interleaves unrelated processes; the analyzers compared consecutive events without grouping by view, producing 5 serious findings (and exit 1) on a healthy 12-event timeline. `memory`, `data_growth`, `render_efficiency`, `state_machine`, and `event_pattern` now group events by `view_module` before any consecutive-event comparison, so a freshly-mounted 220-byte `UserLoginLive` sitting next to a loaded 109 KB render is no longer read as "507x memory growth", and an Index→Login boundary is no longer phantom "keys added/removed" or "unstable state".
+- **Absolute floors alongside ratios** ([#142](https://github.com/lessthanseventy/excessibility/issues/142)). Memory findings require the larger side to clear ~256 KB regardless of ratio (109 KB is an ordinary LiveView heap); a list going `0 → 1` is treated as "appeared", not `∞x` growth. Performance slow/bottleneck findings require an absolute duration floor, so a 40 ms first mount that is "60% of total time" on a short timeline is not flagged.
+- **`render_efficiency` no longer flags healthy renders as wasted** ([#142](https://github.com/lessthanseventy/excessibility/issues/142)). LiveView captures a `handle_event` and its `render` as two events, so the render's own diff is empty even though the interaction changed state. Wasted renders are now measured against the *previous render in the same view*, and the initial paint is never wasted — so a `render_click` that genuinely changed state is not reported as a wasted render.
+- **Consecutive mounts are not flagged as unnecessary re-renders** ([#142](https://github.com/lessthanseventy/excessibility/issues/142)). Repeated mounts come from `LiveViewTest.live/2`'s disconnected+connected double-mount and re-navigation — a capture artifact, not render churn — so `event_pattern`'s rapid-repeat heuristics skip lifecycle events (`mount`, `handle_params`).
+- **Assign traversal stops at opaque library structs** ([#142](https://github.com/lessthanseventy/excessibility/issues/142)). `Ecto.Changeset`, `DateTime`/`Date`/`Time`/`NaiveDateTime`, and `Decimal` collapse to a scalar leaf instead of being walked, so changeset internals (`.types`, `.mappings`, `.validations`) and timestamp microsecond tuples no longer surface as tracked app state in `data_growth`.
+- **Memory growth messages report the actual factor** ([#142](https://github.com/lessthanseventy/excessibility/issues/142)). "Memory grew 0.5x" (which printed `delta/prev`) now reads "grew 1.5x" (`curr/prev`), so the number matches the byte sizes shown alongside it.
+
+
 ## [0.15.3] - 2026-08-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Excessibility helps you test your Phoenix apps for accessibility (WCAG complianc
 2. **After tests**, run `mix excessibility` to check all snapshots with axe-core for WCAG violations
 3. **Lock baselines** with `mix excessibility.baseline` when snapshots represent a known-good state
 4. **Compare changes** with `mix excessibility.compare` to review what changed and approve/reject
-5. **In CI**, axe-core reports accessibility violations alongside your test failures
+5. **Review the blast radius** with `mix excessibility.review` to see which accessibility issues a change newly introduced (JSON output for CI via `--format json`)
+6. **In CI**, axe-core reports accessibility violations alongside your test failures
 
 ## LiveView-Aware Rules
 
@@ -519,6 +520,79 @@ mix excessibility.compare --keep good   # Keep all baselines (reject all changes
 mix excessibility.compare --keep bad    # Accept all new versions as baseline
 ```
 
+## Blast-Radius Review
+
+Where `mix excessibility` checks each snapshot in isolation, `mix excessibility.review` answers a sharper question — *what did this change actually do?* It diffs every current snapshot against its baseline and, per view, reports the regions that changed and the accessibility findings the change **newly introduced** (axe-core violations + LiveView rules), each with a risk tier:
+
+- `block` — a new critical/serious issue (e.g. a keyboard-inaccessible control)
+- `review` — a new moderate/minor issue; worth a human glance
+- `auto` — rendering changed but introduced no accessibility issues
+
+```bash
+# Generate/refresh snapshots, then review against the baseline
+mix test
+mix excessibility.review
+
+# Fail the build on :block (default), :review, or never
+mix excessibility.review --fail-on review
+mix excessibility.review --fail-on never
+
+# Skip the axe-core browser scans and review on the LiveView rules only
+mix excessibility.review --no-axe
+```
+
+### Machine-readable output for CI
+
+Pass `--format json` (or `--json`) to emit a single JSON object on stdout instead of the human report — a stable API for CI and PR bots, so you never scrape printed text:
+
+```bash
+mix excessibility.review --format json
+```
+
+```json
+{
+  "excessibility_version": "0.16.0",
+  "summary": { "block": 1, "review": 0, "auto": 55 },
+  "warnings": [],
+  "behavioral": [],
+  "changes": [
+    {
+      "view": "checkout_review.html",
+      "tier": "block",
+      "region_count": 1,
+      "findings": [
+        {
+          "rule": "reveal_without_announcement",
+          "severity": "serious",
+          "source": "live_view_rules",
+          "selector": "div#cap-reached-banner",
+          "message": "..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+Every finding carries a `source` — `live_view_rules`, `axe`, or `telemetry` — so a consumer can tell which layer produced it (and, when axe degrades, that the results are rules-only). The exit code is unchanged in JSON mode, so CI can gate on the exit status and read the JSON for detail.
+
+### Behavioral findings (telemetry)
+
+With `--timeline`, the review folds in behavioral findings from a telemetry timeline captured by `mix excessibility.debug` — memory leaks, unbounded list growth, render thrash, N+1 queries:
+
+```bash
+mix excessibility.debug test/my_journey_test.exs        # writes test/excessibility/timeline.json
+mix excessibility.review --timeline test/excessibility/timeline.json
+```
+
+Behavioral findings are **advisory by default**. Unlike accessibility findings — which are a true delta against the baseline — they have no baseline and are absolute measurements of a single run, so they don't fail the build. Opt in with `--fail-on-behavioral`:
+
+```bash
+mix excessibility.review --timeline test/excessibility/timeline.json --fail-on-behavioral
+```
+
+The analyzers group events by LiveView before comparing, so a journey test that drives several LiveViews doesn't produce cross-view artifacts (a freshly-mounted view sitting next to a loaded one is not "memory growth").
+
 ## Configuration
 
 All configuration goes in `test/test_helper.exs` or `config/test.exs`:
@@ -592,6 +666,10 @@ Screenshots are saved alongside HTML files with `.png` extension. Playwright is 
 | `mix excessibility.compare` | Compare snapshots against baseline, resolve diffs interactively |
 | `mix excessibility.compare --keep good` | Keep all baseline versions (reject changes) |
 | `mix excessibility.compare --keep bad` | Accept all new versions as baseline |
+| `mix excessibility.review` | Report the accessibility blast radius of changes vs the baseline |
+| `mix excessibility.review --format json` | Emit the review as a single JSON object for CI (`--json` alias) |
+| `mix excessibility.review --fail-on block\|review\|never` | Choose which tier fails the build (default: `block`) |
+| `mix excessibility.review --timeline <file> --fail-on-behavioral` | Fold in behavioral findings and gate on serious ones |
 | `mix excessibility.debug [test args]` | Run tests with telemetry, generate debug report (passthrough to mix test) |
 | `mix excessibility.debug [test args] --format=json` | Output debug report as JSON |
 | `mix excessibility.debug [test args] --format=package` | Create debug package directory |

--- a/docs/telemetry-analysis.md
+++ b/docs/telemetry-analysis.md
@@ -31,9 +31,24 @@ end
 
 **Purpose:** Detect patterns across complete timelines.
 
-**When they run:** After timeline completion, invoked by `mix excessibility.debug`.
+**When they run:** After timeline completion, invoked by `mix excessibility.debug`
+(and folded into `mix excessibility.review --timeline`).
 
 **Output:** Map with `:findings` (list of issues) and `:stats` (summary data).
+
+**Per-view analysis.** A journey test drives several LiveViews, so a raw
+timeline interleaves unrelated processes. Analyzers that compare consecutive
+events (memory growth, render efficiency, state transitions, event patterns)
+group events by `view_module` first, via `Analyzer.group_by_view/1` — an
+adjacent pair spanning two views is an artifact of the interleaving, not the
+code. Findings also apply absolute floors alongside ratios (e.g. memory
+requires the larger side to clear ~256 KB regardless of ratio) so an ordinary
+heap or a `0 → 1` list isn't flagged.
+
+**In reviews.** When surfaced through `mix excessibility.review`, behavioral
+findings are **advisory by default** — unlike accessibility findings they have
+no baseline, so they're absolute measurements of a single run. They only gate
+the build with `--fail-on-behavioral`.
 
 **Example:**
 ```elixir
@@ -96,7 +111,8 @@ Memory range: 2.3 KB → 890 KB (avg: 145 KB)
 ### Basic Analysis
 
 ```bash
-# Run with default analyzers (currently: memory)
+# Run with the default-enabled analyzers (memory, performance, data_growth,
+# render_efficiency, state_machine, event_pattern, and more)
 mix excessibility.debug test/my_test.exs
 ```
 

--- a/lib/excessibility/review.ex
+++ b/lib/excessibility/review.ex
@@ -183,9 +183,13 @@ defmodule Excessibility.Review do
   # — unlike `SnapshotDiff.scan_sequence/2`, which diffs consecutive
   # snapshots within one run and keeps it unconditionally.
   defp content_change_findings(baseline_html, current_html, opts) do
-    if Keyword.get(opts, :content_diff, false),
-      do: SnapshotDiff.live_region_findings(baseline_html, current_html, opts),
-      else: []
+    if Keyword.get(opts, :content_diff, false) do
+      baseline_html
+      |> SnapshotDiff.live_region_findings(current_html, opts)
+      |> Enum.map(&Map.put(&1, :source, :live_view_rules))
+    else
+      []
+    end
   end
 
   # Rule violations (LiveView rules + axe) present in the current snapshot
@@ -219,6 +223,7 @@ defmodule Excessibility.Review do
     html
     |> LiveViewRules.scan(opts)
     |> Map.fetch!(:findings)
+    |> Enum.map(&Map.put(&1, :source, :live_view_rules))
   end
 
   # Selectors embed DOM ids, and Phoenix idiomatically derives those from
@@ -270,7 +275,8 @@ defmodule Excessibility.Review do
         rule: violation.id,
         selector: Enum.join(node.target, " "),
         severity: violation.impact || :moderate,
-        message: violation.help
+        message: violation.help,
+        source: :axe
       }
     end
   end

--- a/lib/mix/tasks/excessibility_review.ex
+++ b/lib/mix/tasks/excessibility_review.ex
@@ -23,6 +23,15 @@ defmodule Mix.Tasks.Excessibility.Review do
       mix excessibility.review --fail-on review
       mix excessibility.review --fail-on never
 
+      # Emit one machine-readable JSON object on stdout instead of the human
+      # report (for CI/PR bots — see the schema below). --json is an alias.
+      mix excessibility.review --format json
+
+      # Also fail the build on a serious *behavioral* finding. Off by default:
+      # behavioral findings have no baseline (they're absolute measurements of
+      # a single run), so they're advisory unless you opt in.
+      mix excessibility.review --timeline test/excessibility/timeline.json --fail-on-behavioral
+
       # Fold in behavioral findings from a telemetry timeline (N+1 queries,
       # dead state, render thrash) captured by `mix excessibility.debug`
       mix excessibility.review --timeline test/excessibility/timeline.json --judge
@@ -55,18 +64,39 @@ defmodule Mix.Tasks.Excessibility.Review do
   def run(args) do
     {opts, _argv, _invalid} =
       OptionParser.parse(args,
-        strict: [fail_on: :string, judge: :boolean, timeline: :string, axe: :boolean, content_diff: :boolean]
+        strict: [
+          fail_on: :string,
+          fail_on_behavioral: :boolean,
+          judge: :boolean,
+          timeline: :string,
+          axe: :boolean,
+          content_diff: :boolean,
+          format: :string,
+          json: :boolean
+        ]
       )
 
     fail_on = parse_fail_on(opts[:fail_on])
+    fail_on_behavioral? = Keyword.get(opts, :fail_on_behavioral, false)
+    json? = json_output?(opts)
 
-    warn_if_stale()
+    stale_warning = stale_warning()
 
     report = Review.review(review_opts(opts))
     report = if Keyword.get(opts, :judge, false), do: Review.judge_changes(report), else: report
 
-    print_report(report)
-    maybe_exit(report, fail_on)
+    if json? do
+      report |> with_run_warnings(stale_warning) |> print_json()
+    else
+      if stale_warning, do: Mix.shell().info(stale_warning <> "\n")
+      print_report(report)
+    end
+
+    maybe_exit(report, fail_on, fail_on_behavioral?)
+  end
+
+  defp json_output?(opts) do
+    Keyword.get(opts, :json, false) or opts[:format] == "json"
   end
 
   # Load a telemetry timeline (mix excessibility.debug writes timeline.json) so
@@ -99,17 +129,26 @@ defmodule Mix.Tasks.Excessibility.Review do
 
   # A report generated from snapshots older than the baseline describes a
   # previous run, not the current change — say so instead of silently
-  # reporting stale numbers.
-  defp warn_if_stale do
+  # reporting stale numbers. Returns the warning text (or nil) so both the
+  # human report and the JSON output can surface it.
+  defp stale_warning do
     with {:ok, newest_snapshot} <- newest_mtime("html_snapshots"),
          {:ok, newest_baseline} <- newest_mtime("baseline"),
          true <- newest_snapshot < newest_baseline do
-      Mix.shell().info(
-        "WARNING: current snapshots predate the baseline — run `mix test` to refresh them before trusting this report.\n"
-      )
+      "WARNING: current snapshots predate the baseline — run `mix test` to refresh them before trusting this report."
     else
-      _ -> :ok
+      _ -> nil
     end
+  end
+
+  # In JSON mode the stale-snapshot notice belongs in the report's warnings
+  # array, not on stdout (which must carry only the JSON object). The
+  # "WARNING: " prefix is stripped so the array holds prose, not log lines.
+  defp with_run_warnings(report, nil), do: report
+
+  defp with_run_warnings(report, stale_warning) do
+    text = String.replace_prefix(stale_warning, "WARNING: ", "")
+    Map.update(report, :warnings, [text], &[text | &1])
   end
 
   defp newest_mtime(subdir) do
@@ -213,19 +252,75 @@ defmodule Mix.Tasks.Excessibility.Review do
   defp tier_rank(:review), do: 1
   defp tier_rank(:auto), do: 2
 
-  defp maybe_exit(report, fail_on) do
-    block? = report.summary.block > 0 or behavioral_serious?(report)
+  # Accessibility tiers gate the build via --fail-on (default :block).
+  # Behavioral findings are advisory by default (they have no baseline, so
+  # they're absolute single-run measurements, issue #142) and only gate the
+  # build when the user opts in with --fail-on-behavioral.
+  defp maybe_exit(report, fail_on, fail_on_behavioral?) do
+    a11y_block? = report.summary.block > 0
+    behavioral_block? = fail_on_behavioral? and behavioral_serious?(report)
 
     cond do
-      fail_on == :block and block? -> exit({:shutdown, 1})
-      fail_on == :review and (block? or report.summary.review > 0) -> exit({:shutdown, 1})
+      behavioral_block? -> exit({:shutdown, 1})
+      fail_on == :block and a11y_block? -> exit({:shutdown, 1})
+      fail_on == :review and (a11y_block? or report.summary.review > 0) -> exit({:shutdown, 1})
       true -> :ok
     end
   end
 
-  # A critical analyzer finding (normalized to :serious) fails the run even
-  # without --judge, the same as a serious accessibility regression.
   defp behavioral_serious?(report) do
     Enum.any?(Map.get(report, :behavioral, []), &(&1.severity == :serious))
+  end
+
+  # ── JSON output (issue #143) ───────────────────────────────────────
+  #
+  # One object on stdout so CI can consume the report without scraping the
+  # human-readable text. Rule ids and severities are atoms internally, so
+  # they're stringified on the way out; each finding carries a `source`
+  # (`live_view_rules` / `axe` / `telemetry`) that the printed report only
+  # implies.
+  defp print_json(report) do
+    report
+    |> json_map()
+    |> Jason.encode!(pretty: true)
+    |> Mix.shell().info()
+  end
+
+  defp json_map(report) do
+    %{
+      excessibility_version: to_string(Application.spec(:excessibility, :vsn)),
+      summary: report.summary,
+      warnings: Map.get(report, :warnings, []),
+      behavioral: Enum.map(Map.get(report, :behavioral, []), &json_behavioral/1),
+      changes: Enum.map(report.changes, &json_change/1)
+    }
+  end
+
+  defp json_behavioral(finding) do
+    %{
+      rule: to_string(finding.rule),
+      severity: to_string(finding.severity),
+      source: to_string(Map.get(finding, :source, :telemetry)),
+      message: finding.message
+    }
+  end
+
+  defp json_change(change) do
+    %{
+      view: change.view,
+      tier: to_string(change.tier),
+      region_count: change.region_count,
+      findings: Enum.map(change.findings, &json_finding/1)
+    }
+  end
+
+  defp json_finding(finding) do
+    %{
+      rule: to_string(finding.rule),
+      severity: to_string(finding.severity),
+      source: to_string(Map.get(finding, :source, :live_view_rules)),
+      selector: Map.get(finding, :selector),
+      message: finding.message
+    }
   end
 end

--- a/lib/telemetry_capture/analyzer.ex
+++ b/lib/telemetry_capture/analyzer.ex
@@ -63,6 +63,27 @@ defmodule Excessibility.TelemetryCapture.Analyzer do
         }
 
   @doc """
+  Splits a timeline's events into per-view sublists, preserving order.
+
+  A journey test drives several LiveViews, so a raw timeline interleaves
+  unrelated processes. Analyzers that compare *consecutive* events (memory
+  growth, render efficiency) must not treat a `UserLoginLive` mount sitting
+  next to a `MarketplaceLive.Index` render as a transition — that's an
+  artifact of the interleaving, not the code (issue #142).
+
+  Events are grouped by `:view_module`; groups appear in first-seen order
+  and events keep their relative order within a group. Events without a
+  `:view_module` (older fixtures, single-view timelines) collapse to one
+  group, so the ungrouped case is unchanged.
+  """
+  @spec group_by_view([map()]) :: [[map()]]
+  def group_by_view(events) do
+    order = events |> Enum.map(&Map.get(&1, :view_module)) |> Enum.uniq()
+    grouped = Enum.group_by(events, &Map.get(&1, :view_module))
+    Enum.map(order, &Map.fetch!(grouped, &1))
+  end
+
+  @doc """
   Gets required enrichers for an analyzer module.
   Returns empty list if not defined.
   """

--- a/lib/telemetry_capture/analyzers/data_growth.ex
+++ b/lib/telemetry_capture/analyzers/data_growth.ex
@@ -43,6 +43,15 @@ defmodule Excessibility.TelemetryCapture.Analyzers.DataGrowth do
 
   @behaviour Excessibility.TelemetryCapture.Analyzer
 
+  alias Excessibility.TelemetryCapture.Analyzer
+
+  # A list going from empty to a single element is normal (issue #142): an
+  # unbounded ratio off a zero baseline (`0 → 1 = ∞x`) isn't a useful
+  # severity input. A from-zero list only warns once it reaches a size worth
+  # a second look; a genuinely large from-zero list still trips the
+  # pagination critical below.
+  @appeared_min 10
+
   def name, do: :data_growth
   def default_enabled?, do: true
   def requires_enrichers, do: [:collection_size]
@@ -52,9 +61,15 @@ defmodule Excessibility.TelemetryCapture.Analyzers.DataGrowth do
   end
 
   def analyze(%{timeline: timeline}, _opts) do
-    list_paths = discover_list_paths(timeline)
-    findings = detect_growth(timeline, list_paths)
-    stats = calculate_stats(list_paths, timeline)
+    # Track each list's size within a single view; a journey test interleaves
+    # LiveViews, so a path that goes `0 → 1` in one view with unrelated events
+    # between must not be compared across the gap (issue #142).
+    findings =
+      timeline
+      |> Analyzer.group_by_view()
+      |> Enum.flat_map(fn events -> detect_growth(events, discover_list_paths(events)) end)
+
+    stats = calculate_stats(discover_list_paths(timeline), timeline)
 
     %{
       findings: findings,
@@ -121,7 +136,7 @@ defmodule Excessibility.TelemetryCapture.Analyzers.DataGrowth do
       critical_growth?(growth_multiplier, max_step_growth, last_size) ->
         [build_finding(:critical, path, sizes, growth_multiplier, last_size, sequences)]
 
-      warning_growth?(growth_multiplier) ->
+      warning_growth?(growth_multiplier, last_size) ->
         [build_finding(:warning, path, sizes, growth_multiplier, last_size, sequences)]
 
       true ->
@@ -134,9 +149,10 @@ defmodule Excessibility.TelemetryCapture.Analyzers.DataGrowth do
       (last_size > 100 and (growth_multiplier == :infinity or growth_multiplier >= 3))
   end
 
-  defp warning_growth?(growth_multiplier) do
-    growth_multiplier == :infinity or growth_multiplier >= 3
-  end
+  # A from-zero list (`:infinity` multiplier) only warns once it has grown to
+  # a size worth a second look — `0 → 1` is just an item appearing (#142).
+  defp warning_growth?(:infinity, last_size), do: last_size >= @appeared_min
+  defp warning_growth?(growth_multiplier, _last_size), do: growth_multiplier >= 3
 
   defp build_finding(severity, path, sizes, growth_multiplier, last_size, sequences) do
     suggest_pagination? = severity == :critical and last_size > 100

--- a/lib/telemetry_capture/analyzers/event_pattern.ex
+++ b/lib/telemetry_capture/analyzers/event_pattern.ex
@@ -39,6 +39,8 @@ defmodule Excessibility.TelemetryCapture.Analyzers.EventPattern do
 
   @behaviour Excessibility.TelemetryCapture.Analyzer
 
+  alias Excessibility.TelemetryCapture.Analyzer
+
   def name, do: :event_pattern
   def default_enabled?, do: true
   def requires_enrichers, do: []
@@ -57,20 +59,28 @@ defmodule Excessibility.TelemetryCapture.Analyzers.EventPattern do
     }
   end
 
+  # Patterns are detected within a view: a journey test interleaves
+  # LiveViews, so mounts of two different views sitting next to each other
+  # aren't "consecutive duplicate" events, and a mount count summed across
+  # views isn't a single view mounting excessively (issue #142). Stats stay
+  # global — they describe the whole run.
   defp detect_patterns(timeline) do
-    consecutive_findings = detect_consecutive_duplicates(timeline)
-    excessive_findings = detect_excessive_events(timeline)
-    optimization_findings = suggest_optimizations(timeline)
-
-    consecutive_findings ++ excessive_findings ++ optimization_findings
+    timeline
+    |> Analyzer.group_by_view()
+    |> Enum.flat_map(fn events ->
+      detect_consecutive_duplicates(events) ++
+        detect_excessive_events(events) ++
+        suggest_optimizations(events)
+    end)
   end
 
   defp detect_consecutive_duplicates(timeline) do
     timeline
     |> Enum.chunk_by(& &1.event)
     |> Enum.flat_map(fn chunk ->
-      if length(chunk) >= 3 do
-        event_type = List.first(chunk).event
+      event_type = List.first(chunk).event
+
+      if length(chunk) >= 3 and not lifecycle_event?(event_type) do
         sequences = Enum.map(chunk, & &1.sequence)
 
         [
@@ -134,7 +144,7 @@ defmodule Excessibility.TelemetryCapture.Analyzers.EventPattern do
   defp detect_rapid_events(timeline) do
     timeline
     |> Enum.chunk_by(& &1.event)
-    |> Enum.filter(fn chunk -> length(chunk) >= 4 end)
+    |> Enum.filter(fn chunk -> length(chunk) >= 4 and not lifecycle_event?(List.first(chunk).event) end)
     |> Enum.map(fn chunk ->
       event_type = List.first(chunk).event
       sequences = Enum.map(chunk, & &1.sequence)
@@ -163,6 +173,17 @@ defmodule Excessibility.TelemetryCapture.Analyzers.EventPattern do
       common_sequences: common_seqs
     }
   end
+
+  # Lifecycle events (mount, handle_params) are not user-driven repeats or
+  # render churn — consecutive mounts come from `LiveViewTest.live/2`'s
+  # disconnected+connected double-mount and re-navigation, so flagging them as
+  # "unnecessary re-renders" is a capture artifact (issue #142). The rapid-fire
+  # heuristics target handle_event:* and render only.
+  defp lifecycle_event?(event) when is_binary(event) do
+    event == "mount" or String.starts_with?(event, "handle_params")
+  end
+
+  defp lifecycle_event?(_event), do: false
 
   defp count_events(timeline) do
     timeline

--- a/lib/telemetry_capture/analyzers/memory.ex
+++ b/lib/telemetry_capture/analyzers/memory.ex
@@ -37,6 +37,14 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Memory do
 
   @behaviour Excessibility.TelemetryCapture.Analyzer
 
+  alias Excessibility.TelemetryCapture.Analyzer
+
+  # A ratio off a tiny denominator (issue #142: a 220-byte freshly-mounted
+  # view followed by a 109 KB loaded view reads as "507x growth") is noise:
+  # 109 KB is an ordinary LiveView heap. A memory finding therefore requires
+  # the larger side to clear an absolute floor, regardless of ratio.
+  @min_notable_bytes 262_144
+
   def name, do: :memory
   def default_enabled?, do: true
   def requires_enrichers, do: [:assign_sizes]
@@ -126,50 +134,61 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Memory do
     bloat_findings ++ leak_findings
   end
 
+  # Consecutive-event comparisons run per view: a journey test interleaves
+  # LiveViews, so adjacent events can belong to different processes (#142).
   defp detect_bloat(timeline, stats) do
     timeline
-    |> Enum.chunk_every(2, 1, :discard)
-    |> Enum.flat_map(fn [prev, curr] ->
-      delta = curr.total_memory - prev.total_memory
-      multiplier = if prev.total_memory > 0, do: delta / prev.total_memory, else: 0
+    |> Analyzer.group_by_view()
+    |> Enum.flat_map(&Enum.chunk_every(&1, 2, 1, :discard))
+    |> Enum.flat_map(fn [prev, curr] -> bloat_for_pair(prev, curr, stats) end)
+  end
 
-      cond do
-        # Critical: 10x growth, or 10x median delta, or > mean + 2std_dev
-        multiplier >= 10 or delta > stats.median_delta * 10 or
-            curr.total_memory > stats.avg + 2 * stats.std_dev ->
-          [
-            %{
-              severity: :critical,
-              message:
-                "Memory grew #{format_multiplier(multiplier)}x between events (#{format_bytes(prev.total_memory)} → #{format_bytes(curr.total_memory)})",
-              events: [prev.sequence, curr.sequence],
-              metadata: %{growth_multiplier: Float.round(multiplier, 1), delta_bytes: delta}
-            }
-          ]
+  defp bloat_for_pair(prev, curr, stats) do
+    delta = curr.total_memory - prev.total_memory
+    # `factor` (curr/prev) is what the message reports, so "grew 1.5x" means
+    # the heap is 1.5x its previous size — not the confusing "grew 0.5x" that
+    # delta/prev produced. The thresholds themselves use delta/prev.
+    factor = if prev.total_memory > 0, do: curr.total_memory / prev.total_memory, else: 0
 
-        # Warning: 3x growth or 3x median delta
-        multiplier >= 3 or delta > stats.median_delta * 3 ->
-          [
-            %{
-              severity: :warning,
-              message:
-                "Memory grew #{format_multiplier(multiplier)}x between events (#{format_bytes(prev.total_memory)} → #{format_bytes(curr.total_memory)})",
-              events: [prev.sequence, curr.sequence],
-              metadata: %{growth_multiplier: Float.round(multiplier, 1), delta_bytes: delta}
-            }
-          ]
+    cond do
+      # An ordinary-sized heap never bloats on ratio alone.
+      curr.total_memory < @min_notable_bytes -> []
+      critical_bloat?(prev, curr, delta, stats) -> [bloat_finding(:critical, prev, curr, factor, delta)]
+      warning_bloat?(prev, delta, stats) -> [bloat_finding(:warning, prev, curr, factor, delta)]
+      true -> []
+    end
+  end
 
-        true ->
-          []
-      end
-    end)
+  # Critical: 10x growth, or 10x median delta, or beyond mean + 2 std_dev.
+  defp critical_bloat?(prev, curr, delta, stats) do
+    ratio(delta, prev.total_memory) >= 10 or delta > stats.median_delta * 10 or
+      curr.total_memory > stats.avg + 2 * stats.std_dev
+  end
+
+  # Warning: 3x growth or 3x median delta.
+  defp warning_bloat?(prev, delta, stats) do
+    ratio(delta, prev.total_memory) >= 3 or delta > stats.median_delta * 3
+  end
+
+  defp ratio(_delta, 0), do: 0
+  defp ratio(delta, prev), do: delta / prev
+
+  defp bloat_finding(severity, prev, curr, factor, delta) do
+    %{
+      severity: severity,
+      message:
+        "Memory grew #{format_multiplier(factor)}x between events (#{format_bytes(prev.total_memory)} → #{format_bytes(curr.total_memory)})",
+      events: [prev.sequence, curr.sequence],
+      metadata: %{growth_multiplier: Float.round(factor, 1), delta_bytes: delta}
+    }
   end
 
   defp detect_leaks(timeline, stats) do
     timeline
-    |> Enum.chunk_every(3, 1, :discard)
+    |> Analyzer.group_by_view()
+    |> Enum.flat_map(&Enum.chunk_every(&1, 3, 1, :discard))
     |> Enum.flat_map(fn chunk ->
-      if significant_consecutive_increases?(chunk, stats) do
+      if significant_consecutive_increases?(chunk, stats) and notable_chunk?(chunk) do
         sequences = Enum.map(chunk, & &1.sequence)
         sizes = Enum.map(chunk, & &1.total_memory)
 
@@ -186,6 +205,12 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Memory do
         []
       end
     end)
+  end
+
+  # Grouping by view can expose a monotonic run that the interleaving used
+  # to mask; a run of ordinary-sized heaps still isn't a leak worth flagging.
+  defp notable_chunk?(chunk) do
+    chunk |> Enum.map(& &1.total_memory) |> Enum.max() >= @min_notable_bytes
   end
 
   defp significant_consecutive_increases?([a, b, c], stats) do

--- a/lib/telemetry_capture/analyzers/performance.ex
+++ b/lib/telemetry_capture/analyzers/performance.ex
@@ -42,6 +42,14 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Performance do
 
   @behaviour Excessibility.TelemetryCapture.Analyzer
 
+  # On a short timeline *some* event is always the majority of total time and
+  # some event is always the relative outlier — that's a statement about
+  # sample size, not the code (issue #142: a 40 ms first mount reported as
+  # "6.7x average" and "60% of total time"). Slow/bottleneck findings
+  # therefore require an absolute duration floor; genuinely slow events
+  # (>1000 ms) still escalate on their own.
+  @min_notable_ms 100
+
   def name, do: :performance
   def default_enabled?, do: true
   def requires_enrichers, do: [:duration]
@@ -133,7 +141,22 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Performance do
       multiplier = if stats.avg_duration > 0, do: duration / stats.avg_duration, else: 0.0
 
       cond do
-        duration > 1000 or duration > threshold_critical ->
+        # A genuinely slow event escalates regardless of the rest of the run.
+        duration > 1000 ->
+          [
+            %{
+              severity: :critical,
+              message: "Very slow event (#{duration}ms, #{format_multiplier(multiplier)}x average)",
+              events: [event.sequence],
+              metadata: %{duration_ms: duration, multiplier: round_float(multiplier, 1)}
+            }
+          ]
+
+        # Below the floor, "Nx average" is sample-size noise, not a problem.
+        duration < @min_notable_ms ->
+          []
+
+        duration > threshold_critical ->
           [
             %{
               severity: :critical,
@@ -165,7 +188,7 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Performance do
     Enum.flat_map(timeline, fn event ->
       duration = Map.get(event, :event_duration_ms)
 
-      if is_nil(duration) or duration <= threshold do
+      if is_nil(duration) or duration <= threshold or duration < @min_notable_ms do
         []
       else
         percentage = round(duration / stats.total_duration * 100)

--- a/lib/telemetry_capture/analyzers/render_efficiency.ex
+++ b/lib/telemetry_capture/analyzers/render_efficiency.ex
@@ -2,8 +2,15 @@ defmodule Excessibility.TelemetryCapture.Analyzers.RenderEfficiency do
   @moduledoc """
   Analyzes render efficiency by detecting wasted renders.
 
-  A "wasted render" is a render event with no state changes.
-  This indicates the LiveView re-rendered unnecessarily.
+  A "wasted render" is a render that repaints identical state — nothing
+  changed since the view last rendered. Crucially this is measured against
+  the **previous render in the same view**, not the immediately preceding
+  timeline event: LiveView captures a `handle_event` and its resulting
+  `render` as two events, so the render's own diff-vs-previous is empty even
+  though the interaction genuinely changed state. Counting that render as
+  wasted would flag every `render_click`/`render_submit` in a healthy test
+  (issue #142). The first render in a view (the initial paint) is never
+  wasted.
 
   ## Thresholds
 
@@ -31,6 +38,14 @@ defmodule Excessibility.TelemetryCapture.Analyzers.RenderEfficiency do
 
   @behaviour Excessibility.TelemetryCapture.Analyzer
 
+  alias Excessibility.TelemetryCapture.Analyzer
+
+  # A "50% of renders were wasted" claim over four samples is a statement
+  # about sample size, not the code (issue #142). The percentage-based
+  # critical needs enough renders to mean something; the absolute
+  # "3+ wasted renders" warning stands on its own.
+  @min_render_sample 5
+
   def name, do: :render_efficiency
   def default_enabled?, do: true
 
@@ -39,10 +54,16 @@ defmodule Excessibility.TelemetryCapture.Analyzers.RenderEfficiency do
   end
 
   def analyze(%{timeline: timeline}, _opts) do
-    render_events = Enum.filter(timeline, &render_event?/1)
-    wasted = Enum.filter(render_events, &wasted_render?/1)
+    # Wasted renders are detected per view: a journey test interleaves
+    # LiveViews, and "changed since the last render" is only meaningful
+    # within one process (issue #142).
+    per_view_wasted =
+      timeline
+      |> Analyzer.group_by_view()
+      |> Enum.map(&wasted_renders_in_view/1)
 
-    render_count = length(render_events)
+    render_count = timeline |> Enum.filter(&render_event?/1) |> length()
+    wasted = Enum.concat(per_view_wasted)
     wasted_count = length(wasted)
     efficiency = if render_count > 0, do: 1 - wasted_count / render_count, else: 1.0
 
@@ -52,17 +73,55 @@ defmodule Excessibility.TelemetryCapture.Analyzers.RenderEfficiency do
       efficiency_ratio: Float.round(efficiency, 2)
     }
 
-    findings = detect_issues(wasted, render_count, wasted_count)
+    findings =
+      Enum.flat_map(per_view_wasted, fn view_wasted ->
+        view_renders = length_of_view_renders(timeline, view_wasted)
+        detect_issues(view_wasted, view_renders, length(view_wasted))
+      end)
 
     %{findings: findings, stats: stats}
+  end
+
+  # Walk a single view's events in order, tracking whether any assign changed
+  # since that view last rendered. A render repainting unchanged state (and
+  # not the initial paint) is wasted.
+  defp wasted_renders_in_view(events) do
+    {wasted, _seen_render?, _changed_since_render?} = Enum.reduce(events, {[], false, false}, &step_render/2)
+    Enum.reverse(wasted)
+  end
+
+  defp step_render(event, {wasted, seen_render?, changed?}) do
+    if render_event?(event) do
+      # A render repainting unchanged state (and not the initial paint) is
+      # wasted; either way it resets the "changed since last render" window.
+      now_changed? = changed? or event_has_changes?(event)
+      {wasted_after(wasted, event, seen_render? and not now_changed?), true, false}
+    else
+      {wasted, seen_render?, changed? or event_has_changes?(event)}
+    end
+  end
+
+  defp wasted_after(wasted, event, true), do: [event | wasted]
+  defp wasted_after(wasted, _event, false), do: wasted
+
+  # The render count for the same view the wasted renders came from. Recomputed
+  # from the timeline so the per-view ratio uses that view's renders only.
+  defp length_of_view_renders(_timeline, []), do: 0
+
+  defp length_of_view_renders(timeline, [wasted | _]) do
+    view = Map.get(wasted, :view_module)
+
+    timeline
+    |> Enum.filter(&(render_event?(&1) and Map.get(&1, :view_module) == view))
+    |> length()
   end
 
   defp render_event?(%{event: "render"}), do: true
   defp render_event?(_), do: false
 
-  defp wasted_render?(%{changes: nil}), do: false
-  defp wasted_render?(%{changes: changes}) when map_size(changes) == 0, do: true
-  defp wasted_render?(_), do: false
+  defp event_has_changes?(%{changes: nil}), do: false
+  defp event_has_changes?(%{changes: changes}) when is_map(changes), do: map_size(changes) > 0
+  defp event_has_changes?(_), do: false
 
   defp detect_issues(_wasted, render_count, _wasted_count) when render_count == 0, do: []
 
@@ -70,7 +129,7 @@ defmodule Excessibility.TelemetryCapture.Analyzers.RenderEfficiency do
     wasted_ratio = wasted_count / render_count
 
     cond do
-      wasted_ratio > 0.3 ->
+      render_count >= @min_render_sample and wasted_ratio > 0.3 ->
         sequences = Enum.map(wasted, & &1.sequence)
 
         [

--- a/lib/telemetry_capture/analyzers/state_machine.ex
+++ b/lib/telemetry_capture/analyzers/state_machine.ex
@@ -43,6 +43,8 @@ defmodule Excessibility.TelemetryCapture.Analyzers.StateMachine do
 
   @behaviour Excessibility.TelemetryCapture.Analyzer
 
+  alias Excessibility.TelemetryCapture.Analyzer
+
   def name, do: :state_machine
   def default_enabled?, do: true
   def requires_enrichers, do: [:state]
@@ -66,9 +68,14 @@ defmodule Excessibility.TelemetryCapture.Analyzers.StateMachine do
     }
   end
 
+  # Transitions are computed within a view: a journey test interleaves
+  # LiveViews, so a pair spanning two views (e.g. an Index render followed by
+  # a UserLoginLive mount) would diff two unrelated processes' key sets and
+  # report phantom "keys added/removed" and "unstable state" (issue #142).
   defp detect_transitions(timeline) do
     timeline
-    |> Enum.chunk_every(2, 1, :discard)
+    |> Analyzer.group_by_view()
+    |> Enum.flat_map(&Enum.chunk_every(&1, 2, 1, :discard))
     |> Enum.map(fn [prev, curr] ->
       prev_keys = MapSet.new(Map.get(prev, :state_keys, []))
       curr_keys = MapSet.new(Map.get(curr, :state_keys, []))

--- a/lib/telemetry_capture/enrichers/collection_size.ex
+++ b/lib/telemetry_capture/enrichers/collection_size.ex
@@ -28,6 +28,11 @@ defmodule Excessibility.TelemetryCapture.Enrichers.CollectionSize do
   def name, do: :collection_size
   def cost, do: :expensive
 
+  # Library structs whose internals are machinery, not app state. Stopping
+  # here keeps changeset internals and timestamp microsecond tuples out of the
+  # tracked list paths even when assign filtering is disabled (issue #142).
+  @opaque_structs [Date, Time, DateTime, NaiveDateTime, Decimal, Ecto.Changeset]
+
   def enrich(assigns, _opts) do
     {list_sizes, total_items} = count_lists(assigns, [])
 
@@ -44,6 +49,8 @@ defmodule Excessibility.TelemetryCapture.Enrichers.CollectionSize do
       total_list_items: total_items
     }
   end
+
+  defp count_lists(%mod{}, _path) when mod in @opaque_structs, do: {%{}, 0}
 
   defp count_lists(value, path) when is_struct(value) do
     value

--- a/lib/telemetry_capture/filter.ex
+++ b/lib/telemetry_capture/filter.ex
@@ -6,6 +6,26 @@ defmodule Excessibility.TelemetryCapture.Filter do
   and other noise to improve signal-to-noise ratio for debugging.
   """
 
+  # Library structs that are machinery, not actionable app state. Descending
+  # into them tracks changeset internals (`.types`, `.mappings`, `.validations`)
+  # and explodes timestamp microsecond tuples into 2-element lists, which the
+  # data_growth analyzer then mistakes for app state (issue #142). They are
+  # collapsed to a scalar leaf instead. Referenced by module atom so Ecto and
+  # Decimal stay optional deps (matching the NotLoaded handling below).
+  @opaque_structs [Date, Time, DateTime, NaiveDateTime, Decimal, Ecto.Changeset]
+
+  @doc false
+  def opaque_struct?(value) when is_struct(value), do: value.__struct__ in @opaque_structs
+  def opaque_struct?(_), do: false
+
+  @doc false
+  def opaque_leaf(struct) do
+    case struct.__struct__ do
+      Ecto.Changeset -> "#Ecto.Changeset<valid?: #{inspect(Map.get(struct, :valid?))}>"
+      _ -> to_string(struct)
+    end
+  end
+
   @doc """
   Removes Ecto-related metadata from assigns.
 
@@ -91,6 +111,10 @@ defmodule Excessibility.TelemetryCapture.Filter do
     |> filter_functions()
   end
 
+  def filter_functions(%mod{} = struct) when mod in @opaque_structs do
+    opaque_leaf(struct)
+  end
+
   def filter_functions(struct) when is_struct(struct) do
     struct
     |> Map.from_struct()
@@ -102,6 +126,9 @@ defmodule Excessibility.TelemetryCapture.Filter do
       cond do
         is_function(value) ->
           acc
+
+        opaque_struct?(value) ->
+          Map.put(acc, key, opaque_leaf(value))
 
         is_struct(value) ->
           # Convert struct to map and filter recursively

--- a/test/integration/telemetry_analysis_test.exs
+++ b/test/integration/telemetry_analysis_test.exs
@@ -23,10 +23,11 @@ defmodule Integration.TelemetryAnalysisTest do
     end
 
     test "analyzers detect issues in timeline" do
-      # Create timeline with deliberate memory bloat
+      # Create timeline with deliberate memory bloat above the absolute floor
+      # (issue #142: a ratio off a tiny heap is noise, so sizes must be large)
       snapshots =
         Enum.map(1..5, fn i ->
-          size = if i == 3, do: 10_000, else: 100
+          size = if i == 3, do: 600_000, else: 1000
           assigns = %{data: String.duplicate("x", size)}
           build_snapshot("event_#{i}", assigns)
         end)
@@ -67,9 +68,10 @@ defmodule Integration.TelemetryAnalysisTest do
     end
 
     test "complete flow: snapshots -> timeline -> analysis -> markdown" do
-      # Build snapshots with memory leak pattern
+      # Build snapshots with a memory leak pattern above the absolute floor
+      # (issue #142: leaks of ordinary-sized heaps aren't worth flagging)
       snapshots =
-        [100, 200, 400, 800, 1600]
+        [300_000, 600_000, 1_200_000, 2_400_000, 4_800_000]
         |> Enum.with_index(1)
         |> Enum.map(fn {size, i} ->
           build_snapshot("event_#{i}", %{data: String.duplicate("x", size)})

--- a/test/mix/tasks/excessibility_review_test.exs
+++ b/test/mix/tasks/excessibility_review_test.exs
@@ -159,6 +159,126 @@ defmodule Mix.Tasks.Excessibility.ReviewTest do
     assert output =~ "orders.html"
   end
 
+  describe "behavioral findings gating (issue #142)" do
+    # A single-view timeline with a genuine serious memory finding (10x+ growth
+    # past the absolute floor), so the exit behavior is exercised for real.
+    @serious_timeline ~s({
+      "test": "x",
+      "duration_ms": 100,
+      "timeline": [
+        {"sequence": 0, "event": "mount", "view_module": "AppWeb.Index", "total_memory": 300000},
+        {"sequence": 1, "event": "render", "view_module": "AppWeb.Index", "total_memory": 5000000},
+        {"sequence": 2, "event": "render", "view_module": "AppWeb.Index", "total_memory": 5100000}
+      ]
+    })
+
+    setup do
+      timeline_path = Path.join(@output_dir, "serious_timeline.json")
+      File.write!(timeline_path, @serious_timeline)
+      on_exit(fn -> File.rm_rf!(timeline_path) end)
+      {:ok, timeline_path: timeline_path}
+    end
+
+    test "a serious behavioral finding is advisory and does not exit by default", %{timeline_path: path} do
+      write_pair("home.html", "<div>a</div>", "<div>a</div>")
+
+      output = capture_io(fn -> ReviewTask.run(["--timeline", path]) end)
+
+      assert output =~ "### Behavioral (telemetry analyzers)"
+      assert output =~ "[serious] memory"
+    end
+
+    test "--fail-on-behavioral exits non-zero on a serious behavioral finding", %{timeline_path: path} do
+      write_pair("home.html", "<div>a</div>", "<div>a</div>")
+
+      capture_io(fn ->
+        assert catch_exit(ReviewTask.run(["--timeline", path, "--fail-on-behavioral"])) == {:shutdown, 1}
+      end)
+    end
+
+    test "--fail-on never still lets --fail-on-behavioral exit", %{timeline_path: path} do
+      write_pair("home.html", "<div>a</div>", "<div>a</div>")
+
+      capture_io(fn ->
+        assert catch_exit(ReviewTask.run(["--timeline", path, "--fail-on", "never", "--fail-on-behavioral"])) ==
+                 {:shutdown, 1}
+      end)
+    end
+  end
+
+  describe "JSON output (issue #143)" do
+    test "--format json emits a single parseable object with the report shape" do
+      write_pair("editor.html", "<div>Save</div>", ~s(<div phx-click="save">Save</div>))
+
+      output =
+        capture_io(fn ->
+          assert catch_exit(ReviewTask.run(["--format", "json"])) == {:shutdown, 1}
+        end)
+
+      json = Jason.decode!(output)
+
+      assert is_binary(json["excessibility_version"])
+      assert json["summary"]["block"] == 1
+      assert is_list(json["warnings"])
+      assert is_list(json["behavioral"])
+
+      change = Enum.find(json["changes"], &(&1["view"] == "editor.html"))
+      assert change["tier"] == "block"
+
+      finding = Enum.find(change["findings"], &(&1["rule"] == "phx_click_on_non_interactive"))
+      assert finding["source"] == "live_view_rules"
+      assert finding["severity"] in ["serious", "critical"]
+      assert is_binary(finding["selector"])
+    end
+
+    test "--json is an alias for --format json" do
+      write_pair("home.html", "<div>a</div>", "<div>a</div>")
+
+      output = capture_io(fn -> ReviewTask.run(["--json"]) end)
+
+      assert {:ok, decoded} = Jason.decode(output)
+      assert Map.has_key?(decoded, "summary")
+      # The human report text must not leak onto stdout in JSON mode.
+      refute output =~ "Blast radius"
+    end
+
+    test "behavioral findings appear in JSON with a telemetry source", %{} do
+      timeline_path = Path.join(@output_dir, "json_timeline.json")
+
+      File.write!(
+        timeline_path,
+        ~s({"test":"x","duration_ms":100,"timeline":[
+          {"sequence":0,"event":"mount","view_module":"AppWeb.Index","total_memory":300000},
+          {"sequence":1,"event":"render","view_module":"AppWeb.Index","total_memory":5000000},
+          {"sequence":2,"event":"render","view_module":"AppWeb.Index","total_memory":5100000}
+        ]})
+      )
+
+      on_exit(fn -> File.rm_rf!(timeline_path) end)
+      write_pair("home.html", "<div>a</div>", "<div>a</div>")
+
+      output = capture_io(fn -> ReviewTask.run(["--json", "--timeline", timeline_path]) end)
+      json = Jason.decode!(output)
+
+      assert [finding | _] = json["behavioral"]
+      assert finding["source"] == "telemetry"
+      assert finding["rule"] == "memory"
+      assert finding["severity"] == "serious"
+    end
+
+    test "the stale-snapshot notice moves into the JSON warnings array" do
+      write_pair("home.html", "<div>a</div>", "<div>a</div>")
+      File.touch!(Path.join(@snapshot_dir, "home.html"), {{2020, 1, 1}, {0, 0, 0}})
+
+      output = capture_io(fn -> ReviewTask.run(["--json"]) end)
+      json = Jason.decode!(output)
+
+      assert Enum.any?(json["warnings"], &(&1 =~ "predate the baseline"))
+      # No bare WARNING line on stdout to corrupt the JSON.
+      refute output =~ "WARNING:"
+    end
+  end
+
   describe "axe-core findings" do
     setup :verify_on_exit!
 

--- a/test/review/behavioral_cross_view_test.exs
+++ b/test/review/behavioral_cross_view_test.exs
@@ -1,0 +1,61 @@
+defmodule Excessibility.Review.BehavioralCrossViewTest do
+  @moduledoc """
+  Regression for issue #142: behavioral analyzers must not raise serious
+  findings on a healthy journey timeline that interleaves several
+  LiveViews. The fixture is the numbers-only 12-event timeline from the
+  issue (a MarketplaceLive.Index journey with UserLoginLive mounts
+  interleaved), which previously produced 5 :serious findings purely from
+  cross-view adjacency and small-sample ratios.
+  """
+  use ExUnit.Case, async: true
+
+  alias Excessibility.Review.Behavioral
+  alias Excessibility.TelemetryCapture.Analyzers.DataGrowth
+  alias Excessibility.TelemetryCapture.Analyzers.Memory
+  alias Excessibility.TelemetryCapture.Analyzers.Performance
+  alias Excessibility.TelemetryCapture.Analyzers.RenderEfficiency
+
+  @fixture Path.join([__DIR__, "..", "support", "fixtures", "timeline_cross_view.json"])
+
+  setup do
+    timeline = @fixture |> File.read!() |> Jason.decode!(keys: :atoms)
+    {:ok, timeline: timeline}
+  end
+
+  test "memory: no findings from cross-view adjacency (finding #1)", %{timeline: timeline} do
+    result = Memory.analyze(timeline, [])
+
+    assert result.findings == [],
+           "expected no memory findings, got: #{inspect(result.findings)}"
+  end
+
+  test "data_growth: 0 -> 1 across views is not flagged (finding #2)", %{timeline: timeline} do
+    result = DataGrowth.analyze(timeline, [])
+
+    assert result.findings == [],
+           "expected no data_growth findings, got: #{inspect(result.findings)}"
+  end
+
+  test "performance: 40ms first mount is not slow/bottleneck (finding #3)", %{timeline: timeline} do
+    result = Performance.analyze(timeline, [])
+
+    assert Enum.all?(result.findings, &(&1.severity != :critical)),
+           "expected no critical performance findings, got: #{inspect(result.findings)}"
+  end
+
+  test "render_efficiency: 2 of 4 renders wasted is below sample floor (finding #4)", %{timeline: timeline} do
+    result = RenderEfficiency.analyze(timeline, [])
+
+    assert result.findings == [],
+           "expected no render_efficiency findings, got: #{inspect(result.findings)}"
+  end
+
+  test "behavioral: healthy timeline yields zero serious findings", %{timeline: timeline} do
+    analyzers = [Memory, DataGrowth, Performance, RenderEfficiency]
+    findings = Behavioral.findings(timeline, analyzers: analyzers)
+
+    serious = Enum.filter(findings, &(&1.severity == :serious))
+
+    assert serious == [], "expected no serious behavioral findings, got: #{inspect(serious)}"
+  end
+end

--- a/test/support/fixtures/timeline_cross_view.json
+++ b/test/support/fixtures/timeline_cross_view.json
@@ -1,0 +1,126 @@
+{
+  "test": "MarketplaceLive journey (healthy)",
+  "duration_ms": 200,
+  "timeline": [
+    {
+      "sequence": 0,
+      "event": "mount",
+      "view_module": "MyAppWeb.MarketplaceLive.Index",
+      "total_memory": 24012,
+      "event_duration_ms": 40,
+      "duration_since_previous_ms": null,
+      "changes": {"page": ["", "index"]},
+      "list_sizes": {"products": 100, "order_form.source.changes.items": 0}
+    },
+    {
+      "sequence": 1,
+      "event": "handle_params",
+      "view_module": "MyAppWeb.MarketplaceLive.Index",
+      "total_memory": 24030,
+      "event_duration_ms": 0,
+      "duration_since_previous_ms": 1,
+      "changes": {"params": ["", "loaded"]},
+      "list_sizes": {"products": 100, "order_form.source.changes.items": 0}
+    },
+    {
+      "sequence": 2,
+      "event": "mount",
+      "view_module": "MyAppWeb.MarketplaceLive.Index",
+      "total_memory": 24012,
+      "event_duration_ms": 4,
+      "duration_since_previous_ms": 93,
+      "changes": {"page": ["", "index"]},
+      "list_sizes": {"products": 100, "order_form.source.changes.items": 0}
+    },
+    {
+      "sequence": 3,
+      "event": "handle_params",
+      "view_module": "MyAppWeb.MarketplaceLive.Index",
+      "total_memory": 24030,
+      "event_duration_ms": 0,
+      "duration_since_previous_ms": 0,
+      "changes": {"params": ["", "loaded"]},
+      "list_sizes": {"products": 100, "order_form.source.changes.items": 0}
+    },
+    {
+      "sequence": 4,
+      "event": "render",
+      "view_module": "MyAppWeb.MarketplaceLive.Index",
+      "total_memory": 24030,
+      "event_duration_ms": 2,
+      "duration_since_previous_ms": 3,
+      "changes": {},
+      "list_sizes": {"products": 100, "order_form.source.changes.items": 0}
+    },
+    {
+      "sequence": 5,
+      "event": "render",
+      "view_module": "MyAppWeb.MarketplaceLive.Index",
+      "total_memory": 36831,
+      "event_duration_ms": 14,
+      "duration_since_previous_ms": 38,
+      "changes": {"products": ["old", "new"]},
+      "list_sizes": {"products": 100, "order_form.source.changes.items": 0}
+    },
+    {
+      "sequence": 6,
+      "event": "mount",
+      "view_module": "MyAppWeb.UserLoginLive",
+      "total_memory": 220,
+      "event_duration_ms": 0,
+      "duration_since_previous_ms": 10,
+      "changes": {"form": ["", "blank"]},
+      "list_sizes": {"login_form.errors": 0}
+    },
+    {
+      "sequence": 7,
+      "event": "render",
+      "view_module": "MyAppWeb.MarketplaceLive.Index",
+      "total_memory": 111919,
+      "event_duration_ms": 0,
+      "duration_since_previous_ms": 27,
+      "changes": {},
+      "list_sizes": {"products": 100, "order_form.source.changes.items": 1}
+    },
+    {
+      "sequence": 8,
+      "event": "mount",
+      "view_module": "MyAppWeb.UserLoginLive",
+      "total_memory": 220,
+      "event_duration_ms": 0,
+      "duration_since_previous_ms": 12,
+      "changes": {"form": ["", "blank"]},
+      "list_sizes": {"login_form.errors": 0}
+    },
+    {
+      "sequence": 9,
+      "event": "handle_event:event",
+      "view_module": "MyAppWeb.MarketplaceLive.Index",
+      "total_memory": 111989,
+      "event_duration_ms": 0,
+      "duration_since_previous_ms": 3,
+      "changes": {"cart": ["empty", "one"]},
+      "list_sizes": {"products": 100, "order_form.source.changes.items": 1}
+    },
+    {
+      "sequence": 10,
+      "event": "render",
+      "view_module": "MyAppWeb.MarketplaceLive.Index",
+      "total_memory": 111989,
+      "event_duration_ms": 7,
+      "duration_since_previous_ms": 8,
+      "changes": {"cart": ["empty", "one"]},
+      "list_sizes": {"products": 100, "order_form.source.changes.items": 1}
+    },
+    {
+      "sequence": 11,
+      "event": "mount",
+      "view_module": "MyAppWeb.UserLoginLive",
+      "total_memory": 220,
+      "event_duration_ms": 0,
+      "duration_since_previous_ms": 5,
+      "changes": {"form": ["", "blank"]},
+      "list_sizes": {"login_form.errors": 0}
+    }
+  ]
+}

--- a/test/telemetry_capture/analyzers/event_pattern_test.exs
+++ b/test/telemetry_capture/analyzers/event_pattern_test.exs
@@ -195,5 +195,40 @@ defmodule Excessibility.TelemetryCapture.Analyzers.EventPatternTest do
         assert finding.events != []
       end
     end
+
+    test "mounts of different interleaved views are not consecutive duplicates (issue #142)" do
+      # One Index mount next to two Login mounts is not "3 consecutive mounts"
+      # of one view — grouping by view keeps the counts honest.
+      timeline = %{
+        timeline: [
+          %{sequence: 1, event: "mount", view_module: "AppWeb.Index"},
+          %{sequence: 2, event: "mount", view_module: "AppWeb.Login"},
+          %{sequence: 3, event: "mount", view_module: "AppWeb.Login"}
+        ]
+      }
+
+      result = EventPattern.analyze(timeline, [])
+
+      refute Enum.any?(result.findings, &(&1.message =~ "consecutive")),
+             "expected no consecutive-duplicate finding across views, got: #{inspect(result.findings)}"
+    end
+
+    test "consecutive mounts are not flagged as unnecessary re-renders (issue #142)" do
+      # Repeated mounts come from LiveViewTest's disconnected+connected mount
+      # and re-navigation — a capture artifact, not render churn.
+      timeline = %{
+        timeline: [
+          %{sequence: 1, event: "mount", view_module: "AppWeb.Index"},
+          %{sequence: 2, event: "mount", view_module: "AppWeb.Index"},
+          %{sequence: 3, event: "mount", view_module: "AppWeb.Index"},
+          %{sequence: 4, event: "mount", view_module: "AppWeb.Index"}
+        ]
+      }
+
+      result = EventPattern.analyze(timeline, [])
+
+      refute Enum.any?(result.findings, &(&1.message =~ "consecutive" or &1.message =~ "Rapid")),
+             "expected no consecutive/rapid finding for mounts, got: #{inspect(result.findings)}"
+    end
   end
 end

--- a/test/telemetry_capture/analyzers/memory_test.exs
+++ b/test/telemetry_capture/analyzers/memory_test.exs
@@ -49,8 +49,9 @@ defmodule Excessibility.TelemetryCapture.Analyzers.MemoryTest do
     end
 
     test "detects large growth between events" do
-      # 10x growth from event 1 to 2
-      timeline = build_timeline([1000, 10_000, 11_000])
+      # 10x growth from event 1 to 2, above the absolute floor (issue #142:
+      # a ratio off a tiny heap is noise, so sizes must clear a few hundred KB)
+      timeline = build_timeline([300_000, 3_000_000, 3_300_000])
       result = Memory.analyze(timeline, [])
 
       assert result.findings != []
@@ -59,8 +60,8 @@ defmodule Excessibility.TelemetryCapture.Analyzers.MemoryTest do
     end
 
     test "detects memory leak pattern" do
-      # 3+ consecutive increases
-      timeline = build_timeline([1000, 2000, 4000, 8000, 16_000])
+      # 3+ consecutive increases past the absolute floor (issue #142)
+      timeline = build_timeline([300_000, 600_000, 1_200_000, 2_400_000, 4_800_000])
       result = Memory.analyze(timeline, [])
 
       assert result.findings != []

--- a/test/telemetry_capture/analyzers/render_efficiency_test.exs
+++ b/test/telemetry_capture/analyzers/render_efficiency_test.exs
@@ -44,9 +44,17 @@ defmodule Excessibility.TelemetryCapture.Analyzers.RenderEfficiencyTest do
     end
 
     test "detects wasted render with no changes" do
+      # 6 renders repainting identical state. The first is the initial paint
+      # (never wasted); the other 5 are wasted — enough samples for the
+      # percentage-based critical (issue #142: a % claim over a couple of
+      # renders is sample-size noise).
       timeline =
         build_timeline([
           %{event: "mount", changes: nil},
+          %{event: "render", changes: %{}},
+          %{event: "render", changes: %{}},
+          %{event: "render", changes: %{}},
+          %{event: "render", changes: %{}},
           %{event: "render", changes: %{}},
           %{event: "render", changes: %{}}
         ])
@@ -54,18 +62,38 @@ defmodule Excessibility.TelemetryCapture.Analyzers.RenderEfficiencyTest do
       result = RenderEfficiency.analyze(timeline, [])
 
       assert result.findings != []
-      # 100% wasted (2/2) triggers critical threshold (>30%)
       assert Enum.any?(result.findings, &(&1.severity == :critical))
-      assert result.stats.wasted_render_count == 2
+      assert result.stats.wasted_render_count == 5
+    end
+
+    test "a render following a real state change is not wasted (issue #142)" do
+      # LiveView captures a handle_event and its render as two events, so the
+      # render's own diff is empty even though the interaction changed state.
+      timeline =
+        build_timeline([
+          %{event: "mount", changes: nil},
+          %{event: "render", changes: %{}},
+          %{event: "handle_event:add", changes: %{cart: {[], [1]}}},
+          %{event: "render", changes: %{}},
+          %{event: "handle_event:add", changes: %{cart: {[1], [2, 1]}}},
+          %{event: "render", changes: %{}}
+        ])
+
+      result = RenderEfficiency.analyze(timeline, [])
+
+      assert result.stats.wasted_render_count == 0
+      assert result.findings == []
     end
 
     test "critical when >30% wasted" do
-      # 4 renders, 2 wasted = 50%
+      # 6 renders, 3 wasted = 50%, above the minimum sample size (issue #142)
       timeline =
         build_timeline([
           %{event: "render", changes: %{a: {1, 2}}},
           %{event: "render", changes: %{}},
           %{event: "render", changes: %{b: {1, 2}}},
+          %{event: "render", changes: %{}},
+          %{event: "render", changes: %{c: {1, 2}}},
           %{event: "render", changes: %{}}
         ])
 

--- a/test/telemetry_capture/analyzers/state_machine_test.exs
+++ b/test/telemetry_capture/analyzers/state_machine_test.exs
@@ -200,5 +200,22 @@ defmodule Excessibility.TelemetryCapture.Analyzers.StateMachineTest do
       # Should not crash, treat as no state data
       assert result.findings == []
     end
+
+    test "does not report phantom transitions across interleaved views (issue #142)" do
+      # An Index render followed by a Login mount is two different processes;
+      # diffing their key sets would report keys added/removed and unstable
+      # state that never happened. Grouping by view removes the phantom.
+      timeline = %{
+        timeline: [
+          %{sequence: 1, event: "render", view_module: "AppWeb.Index", state_keys: [:products, :cart]},
+          %{sequence: 2, event: "mount", view_module: "AppWeb.Login", state_keys: [:email]},
+          %{sequence: 3, event: "render", view_module: "AppWeb.Index", state_keys: [:products, :cart]}
+        ]
+      }
+
+      result = StateMachine.analyze(timeline, [])
+
+      assert result.findings == []
+    end
   end
 end

--- a/test/telemetry_capture/enrichers/collection_size_test.exs
+++ b/test/telemetry_capture/enrichers/collection_size_test.exs
@@ -21,6 +21,36 @@ defmodule Excessibility.TelemetryCapture.Enrichers.CollectionSizeTest do
       assert Map.has_key?(result, :total_list_items)
     end
 
+    test "stops at opaque library structs instead of counting their internals (issue #142)" do
+      # A Phoenix form's changeset carries Ecto machinery (types, mappings,
+      # validations) and schema timestamps carry microsecond tuples — none of
+      # which is actionable app state. The traversal must treat these as leaves.
+      changeset = %Ecto.Changeset{
+        data: %{},
+        changes: %{items: [%{id: 1}]},
+        types: %{name: :string, code: {:parameterized, :enum, %{mappings: [a: 1, b: 2]}}},
+        valid?: true
+      }
+
+      assigns = %{
+        order_form: %{source: changeset},
+        created_at: ~U[2024-01-01 12:00:00.123456Z],
+        products: [1, 2, 3]
+      }
+
+      result = CollectionSize.enrich(assigns, [])
+
+      keys = Enum.map(Map.keys(result.list_sizes), &to_string/1)
+
+      # Without a stop, the changeset's own list fields (constraints, errors,
+      # empty_values, changes.items) all leak in as `order_form.source.*`.
+      refute Enum.any?(keys, &(&1 =~ "source")),
+             "expected no changeset internals in list_sizes, got: #{inspect(keys)}"
+
+      # Real app lists are still tracked.
+      assert result.list_sizes[:products] == 3
+    end
+
     test "counts lists at top level" do
       assigns = %{
         products: [1, 2, 3],

--- a/test/telemetry_capture/filter_test.exs
+++ b/test/telemetry_capture/filter_test.exs
@@ -371,6 +371,47 @@ defmodule Excessibility.TelemetryCapture.FilterTest do
     end
   end
 
+  describe "opaque library structs (issue #142)" do
+    test "prunes Ecto.Changeset and DateTime to scalar leaves instead of exploding them" do
+      changeset = %Ecto.Changeset{
+        data: %{},
+        changes: %{items: [%{id: 1}]},
+        types: %{name: :string},
+        valid?: true
+      }
+
+      assigns = %{
+        order_form: %{source: changeset},
+        created_at: ~U[2024-01-01 12:00:00.123456Z],
+        keep: "value"
+      }
+
+      result = Filter.filter_assigns(assigns)
+
+      # The changeset collapses to a leaf, not a nested map of its internals.
+      refute is_map(result.order_form.source)
+      refute is_struct(result.order_form.source)
+
+      # The datetime collapses too, so its microsecond tuple never becomes a
+      # 2-element list that data_growth would count.
+      refute is_map(result.created_at)
+
+      assert result.keep == "value"
+      # Everything stays JSON-encodable.
+      assert {:ok, _json} = Jason.encode(result)
+    end
+
+    test "leaves opaque structs alone when function filtering is disabled (--full)" do
+      assigns = %{created_at: ~U[2024-01-01 12:00:00Z]}
+
+      result = Filter.filter_assigns(assigns, filter_functions: false)
+
+      # --full keeps the raw struct; opaque pruning rides along with function
+      # filtering, which is where struct traversal happens.
+      assert is_struct(result.created_at, DateTime)
+    end
+  end
+
   describe "filter_assigns/2" do
     test "applies all filters by default" do
       callback = fn -> :ok end


### PR DESCRIPTION
Closes #142. Closes #143.

## What & why

`mix excessibility.review --timeline` produced **5 serious behavioral findings (and exit 1)** on a completely healthy LiveView journey (#142), and the only machine interface to the review was scraping printed text (#143). This PR fixes both, and — treating the issues as guidance rather than prescription — also cleans up several adjacent false positives an end-to-end run against a real Phoenix app exposed.

## #142 — behavioral analyzers on healthy timelines

Root cause: a journey test drives several LiveViews, so the timeline interleaves unrelated processes, and the analyzers compared consecutive events without grouping by view.

- **Group by view** (`Analyzer.group_by_view/1`) before any consecutive-event comparison in `memory`, `data_growth`, `render_efficiency`, `state_machine`, and `event_pattern`. A freshly-mounted 220-byte `UserLoginLive` next to a loaded 109 KB render is no longer "507x memory growth"; an Index→Login boundary is no longer phantom "keys added/removed".
- **Absolute floors alongside ratios** — memory requires the larger side to clear ~256 KB regardless of ratio; a `0 → 1` list is "appeared", not `∞x`; performance slow/bottleneck require an absolute duration floor.
- **Stop assign traversal at opaque library structs** — `Ecto.Changeset`, `DateTime`/`Date`/`Time`/`NaiveDateTime`, `Decimal` collapse to a scalar leaf, so changeset internals and timestamp microsecond tuples stop being counted as app state.
- **Advisory by default** — behavioral findings have no baseline, so they no longer fail the build; opt in with `--fail-on-behavioral`. Accessibility tiers still gate via `--fail-on`.

Exposed by the E2E and also fixed:
- **`render_efficiency`** measured wasted renders against the immediately-preceding `handle_event` (LiveView captures event + render as two events), flagging every healthy `render_click`. Now measured against the previous render in the same view; the initial paint is never wasted.
- **`event_pattern`** flagged consecutive *mounts* as "unnecessary re-renders" — those come from `LiveViewTest.live/2`'s double-mount + re-navigation. Lifecycle events are now skipped by the rapid-repeat heuristics.
- **Memory messages** printed `delta/prev` ("grew 0.5x"); now `curr/prev` ("grew 1.5x").

## #143 — JSON output

`mix excessibility.review --format json` (`--json` alias) emits one object on stdout — `excessibility_version`, `summary`, `warnings`, `behavioral`, `changes` — with a `source` (`live_view_rules` / `axe` / `telemetry`) on every finding. The stale-snapshot notice moves into `warnings` so stdout is only the JSON object; the human report stays the default.

## Validation

- Full suite green (795 tests), credo `--strict` clean, formatted.
- New cross-view regression fixture/test reproduces the exact 5 findings from #142 and asserts they're gone.
- **End-to-end against a real Phoenix app** (a healthy interleaved journey + deliberately-broken views):
  - Healthy journey → **0 behavioral findings, exit 0** (was 5 serious + exit 1).
  - Broken views → memory leak (705 KB), unbounded list (`log` 0→150 → pagination), 328 KB re-diff still **caught** — the floors don't over-suppress real problems.
  - `--fail-on-behavioral` flips the broken run to exit 1; JSON validated with `source` fields.

## Not included
Version bump / release will come in a separate PR, per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)