### PR TITLE
Release v0.16.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Excessibility.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/lessthanseventy/excessibility"
-  @version "0.15.3"
+  @version "0.16.0"
 
   def project do
     [


### PR DESCRIPTION
Bumps `@version` to `0.16.0` for the behavioral-review and JSON-output work merged in #144.

Minor (dot) release: adds `mix excessibility.review --format json` and changes behavioral findings to advisory-by-default — a new feature plus a default-behavior change, which is a minor bump for a pre-1.0 library (not a `1.0.0` API-stability commitment).

CHANGELOG `[0.16.0]` was finalized in #144; this commit is the `mix.exs` version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)