### PR TITLE
Ecto query capture + memory/perf analyzer fixes, v0.17.0 (#146, #147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-08-06
+
+### Added
+- **Ecto query capture, so `ecto_query_analysis` can actually fire** ([#147](https://github.com/lessthanseventy/excessibility/issues/147)). The analyzer reads `ecto_queries`/`ecto_query_count`, but nothing populated them — the capture layer only attached to LiveView telemetry, so N+1 detection (the most common real LiveView performance defect) silently never ran. Capture now attaches to each configured repo's `[..., :query]` telemetry event, accumulates queries in the emitting process, and attributes them to the LiveView event that ran them. Configure the repos to watch: `config :excessibility, ecto_repos: [MyApp.Repo]`. When `ecto_query_analysis` would run but no repos are configured, capture logs that N+1 detection is off instead of reporting a green (empty) section.
+
+### Changed
+- **`message_flooding` is no longer enabled by default** ([#147](https://github.com/lessthanseventy/excessibility/issues/147)). It reads `handle_info:*` timeline events, but Phoenix LiveView emits no `handle_info` telemetry and the capture layer doesn't hook it, so the analyzer could never fire — shipping it enabled implied working coverage while staying silent. It is now opt-in until `handle_info` capture lands.
+- **The performance analyzer's "very slow" ceiling is configurable, and its relative nature is documented.** It is an outlier detector (an event much slower than the rest of the run, the event dominating total time, or one over an absolute ceiling) computed from test timings — so *uniformly* slow code in the ~100 ms–1 s band isn't flagged. That's deliberate (sandbox/cold-mount timings aren't production latency), but it's now called out in the analyzer docs and README, and the absolute ceiling is tunable for teams with representative timings via `config :excessibility, slow_event_ms: 400` (default 1000).
+
+### Fixed
+- **Memory analyzer no longer reports a flat plateau as growth** ([#146](https://github.com/lessthanseventy/excessibility/issues/146)). The 0.16.0 absolute floor gated the size but not the ratio, so a run holding steady at 1.3 MB (a global outlier above the floor) was reported `[serious] Memory grew 1.0x`. A "grew Nx" finding now also requires the ratio to clear a minimum — a flat or shrinking transition isn't bloat. (The `consecutive growth` leak path already required a strict increase, so a flat plateau never qualified there.)
+
+
 ## [0.16.0] - 2026-08-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,9 +145,8 @@ This generates `timeline.json` with event flow, memory usage, and pattern analys
 - `performance` - Identifies slow events and bottlenecks
 - `data_growth` - Analyzes list growth patterns
 - `event_pattern` - Detects inefficient event patterns
-- `ecto_query_analysis` - Full Ecto query analysis with N+1 detection
+- `ecto_query_analysis` - Full Ecto query analysis with N+1 detection (requires `config :excessibility, ecto_repos: [MyApp.Repo]`)
 - `assign_diff` - Detects large assigns re-diffed over the wire
-- `message_flooding` - Detects high-frequency handle_info patterns
 - `state_machine` - Analyzes state transitions
 - `render_efficiency` - Detects wasted renders with no state changes
 - `assign_lifecycle` - Finds dead state (assigns that never change)
@@ -160,6 +159,7 @@ This generates `timeline.json` with event flow, memory usage, and pattern analys
 - `cascade_effect` - Detects rapid event cascades (use `--analyze=cascade_effect`)
 - `hypothesis` - Root cause suggestions (use `--analyze=hypothesis`)
 - `code_pointer` - Maps events to source locations (use `--analyze=code_pointer`)
+- `message_flooding` - Detects high-frequency handle_info patterns (dormant: LiveView emits no handle_info telemetry yet, use `--analyze=message_flooding`)
 - `accessibility_correlation` - Flags state changes with a11y implications (use `--analyze=accessibility_correlation`)
 - `component_rerender` - Detects unnecessary component re-renders (use `--analyze=component_rerender`)
 - `push_event_volume` - Detects excessive push_event volume to JS hooks (use `--analyze=push_event_volume`)
@@ -325,6 +325,7 @@ All configuration in `test/test_helper.exs` or `config/test.exs`:
 - `:node_modules_path` - Path to a host `node_modules` providing `playwright` and `@axe-core/playwright` (default: bundled copy in `assets/`)
 - `:pa11y_config` - Path to pa11y.json (default: `"pa11y.json"`)
 - `:head_render_path` - Route for `<head>` extraction (default: `"/"`)
+- `:ecto_repos` - Repos to capture query telemetry from for N+1/query analysis (default: `[]`, e.g. `[MyApp.Repo]`)
 - `:custom_enrichers` - List of custom enricher modules (default: `[]`)
 - `:custom_analyzers` - List of custom analyzer modules (default: `[]`)
 

--- a/README.md
+++ b/README.md
@@ -611,6 +611,8 @@ All configuration goes in `test/test_helper.exs` or `config/test.exs`:
 | `:check_clipping` | No | `false` | Flag interactive elements mostly outside the visible area, plus page-level horizontal overflow |
 | `:clipping_ratio` | No | `0.9` | Minimum visible-width ratio before an element counts as clipped |
 | `:head_render_path` | No | `"/"` | Route used for rendering `<head>` content |
+| `:ecto_repos` | No | `[]` | Repos to capture query telemetry from, enabling N+1 / query analysis in `mix excessibility.debug` and `--timeline` reviews (e.g. `[MyApp.Repo]`) |
+| `:slow_event_ms` | No | `1000` | Absolute "very slow event" ceiling for the performance analyzer. Performance findings are otherwise **relative** (outliers, bottleneck-share) and computed from test timings, so uniformly-slow code isn't flagged — lower this only if your test timings are representative of production |
 | `:custom_enrichers` | No | `[]` | List of custom enricher modules (see Timeline Analysis section above) |
 | `:custom_analyzers` | No | `[]` | List of custom analyzer modules (see Timeline Analysis section above) |
 

--- a/docs/telemetry-analysis.md
+++ b/docs/telemetry-analysis.md
@@ -50,6 +50,25 @@ findings are **advisory by default** — unlike accessibility findings they have
 no baseline, so they're absolute measurements of a single run. They only gate
 the build with `--fail-on-behavioral`.
 
+**Performance is a relative signal.** The `performance` analyzer flags
+outliers (an event much slower than the rest of the run), the single event
+that dominates total time, and anything over an absolute ceiling
+(`:slow_event_ms`, default 1000ms). It does **not** flag uniformly slow code —
+if every event takes 400ms, nothing is an outlier and nothing crosses the
+ceiling. That is deliberate: these are test timings (sandbox, cold mounts),
+not production latency, so absolute per-event thresholds would mostly flag a
+slow CI box. Treat a green performance section as "no relative regression",
+not "fast"; lower `config :excessibility, slow_event_ms: 400` if your timings
+are representative and you want an absolute budget.
+
+**Ecto query capture.** `ecto_query_analysis` (N+1 detection) needs the queries
+each event ran. Capture attaches to each configured repo's `[..., :query]`
+telemetry event and attributes queries to the in-flight LiveView event — set
+`config :excessibility, ecto_repos: [MyApp.Repo]` to enable it. Without it,
+capture logs that N+1 detection is off rather than reporting an empty section.
+`message_flooding` is dormant (opt-in) until the capture layer emits
+`handle_info` events, which LiveView does not provide by default.
+
 **Example:**
 ```elixir
 defmodule MyAnalyzer do

--- a/lib/telemetry_capture.ex
+++ b/lib/telemetry_capture.ex
@@ -6,11 +6,15 @@ defmodule Excessibility.TelemetryCapture do
   snapshots when LiveView events occur, with no test code changes required.
   """
 
+  alias Excessibility.TelemetryCapture.Enrichers.EctoQueries
   alias Excessibility.TelemetryCapture.Formatter
   alias Excessibility.TelemetryCapture.Registry
   alias Excessibility.TelemetryCapture.Timeline
 
   require Logger
+
+  @ecto_handler_id "excessibility-ecto-capture"
+  @ecto_process_key :excessibility_ecto_queries
 
   @doc """
   Attaches telemetry handlers for automatic snapshot capture.
@@ -34,6 +38,8 @@ defmodule Excessibility.TelemetryCapture do
       &handle_event/4,
       nil
     )
+
+    attach_ecto()
   end
 
   @doc """
@@ -41,6 +47,81 @@ defmodule Excessibility.TelemetryCapture do
   """
   def detach do
     :telemetry.detach("excessibility-capture")
+    :telemetry.detach(@ecto_handler_id)
+  rescue
+    _ -> :ok
+  end
+
+  # Ecto queries fire in the LiveView process while it handles an event, but
+  # the enrichment that reads them runs post-hoc from ETS snapshots — so we
+  # accumulate queries in the emitting process's dictionary and flush them
+  # onto each captured event (issue #147). Without configured repos there is
+  # no query event to attach to, so ecto_query_analysis stays dark; say so
+  # once instead of silently reporting a green (empty) N+1 section.
+  defp attach_ecto do
+    case configured_repos() do
+      [] ->
+        Logger.info(
+          "Excessibility: ecto_query_analysis is enabled but no :ecto_repos are configured, " <>
+            "so N+1 detection is off. Set `config :excessibility, ecto_repos: [MyApp.Repo]`."
+        )
+
+      _repos ->
+        :telemetry.attach_many(@ecto_handler_id, ecto_query_events(), &handle_ecto_query/4, nil)
+    end
+
+    :ok
+  rescue
+    # A misconfigured/unstarted repo must never break capture.
+    error ->
+      Logger.warning("Excessibility: could not attach Ecto query capture: #{inspect(error)}")
+      :ok
+  end
+
+  defp configured_repos do
+    Application.get_env(:excessibility, :ecto_repos, [])
+  end
+
+  @doc """
+  The Ecto `[..., :query]` telemetry events for the configured `:ecto_repos`.
+  """
+  def ecto_query_events do
+    Enum.map(configured_repos(), &query_event/1)
+  end
+
+  # An Ecto repo emits queries at `telemetry_prefix ++ [:query]`. The prefix
+  # defaults to the repo module's segments as atoms (MyApp.Repo -> [:my_app,
+  # :repo]); a repo that overrides `:telemetry_prefix` is honored.
+  defp query_event(repo) do
+    prefix =
+      case repo_telemetry_prefix(repo) do
+        nil -> repo |> Module.split() |> Enum.map(&(&1 |> Macro.underscore() |> String.to_atom()))
+        prefix -> prefix
+      end
+
+    prefix ++ [:query]
+  end
+
+  defp repo_telemetry_prefix(repo) do
+    if function_exported?(repo, :config, 0), do: repo.config()[:telemetry_prefix]
+  rescue
+    _ -> nil
+  end
+
+  defp handle_ecto_query(_event, measurements, metadata, _config) do
+    record = EctoQueries.build_query_record(measurements, metadata)
+    Process.put(@ecto_process_key, [record | Process.get(@ecto_process_key, [])])
+  end
+
+  @doc """
+  Returns and clears the Ecto queries accumulated in the current process
+  since the last flush, oldest first. Called at each captured event so
+  queries are attributed to the event that ran them.
+  """
+  def flush_ecto_queries do
+    queries = @ecto_process_key |> Process.get([]) |> Enum.reverse()
+    Process.delete(@ecto_process_key)
+    queries
   end
 
   @doc """
@@ -76,8 +157,9 @@ defmodule Excessibility.TelemetryCapture do
     if socket do
       clean_assigns = extract_clean_assigns(socket)
       view_module = extract_view_module(socket, metadata)
+      ecto_queries = flush_ecto_queries()
 
-      store_snapshot(event_type, clean_assigns, view_module, metadata, measurements)
+      store_snapshot(event_type, clean_assigns, view_module, metadata, measurements, ecto_queries)
     else
       Logger.debug("Excessibility: No socket in metadata for #{event_type}")
     end
@@ -108,7 +190,7 @@ defmodule Excessibility.TelemetryCapture do
     end
   end
 
-  defp store_snapshot(event_type, clean_assigns, view_module, metadata, measurements) do
+  defp store_snapshot(event_type, clean_assigns, view_module, metadata, measurements, ecto_queries) do
     key = {DateTime.utc_now(), :erlang.unique_integer([:monotonic])}
 
     snapshot = %{
@@ -117,7 +199,8 @@ defmodule Excessibility.TelemetryCapture do
       timestamp: DateTime.utc_now(),
       view_module: view_module,
       metadata_keys: Map.keys(metadata),
-      measurements: measurements
+      measurements: measurements,
+      ecto_queries: ecto_queries
     }
 
     :ets.insert(:excessibility_snapshots, {key, snapshot})

--- a/lib/telemetry_capture/analyzers/memory.ex
+++ b/lib/telemetry_capture/analyzers/memory.ex
@@ -45,6 +45,12 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Memory do
   # the larger side to clear an absolute floor, regardless of ratio.
   @min_notable_bytes 262_144
 
+  # The floor gates the size, but not the growth: a run that holds steady at
+  # 1.3 MB is a global outlier that clears the floor yet grew 0% (issue #146,
+  # reported as "grew 1.0x"). A "grew Nx" finding therefore also requires the
+  # ratio to clear a minimum — a flat or shrinking transition isn't bloat.
+  @min_growth_factor 1.2
+
   def name, do: :memory
   def default_enabled?, do: true
   def requires_enrichers, do: [:assign_sizes]
@@ -148,16 +154,26 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Memory do
     # `factor` (curr/prev) is what the message reports, so "grew 1.5x" means
     # the heap is 1.5x its previous size — not the confusing "grew 0.5x" that
     # delta/prev produced. The thresholds themselves use delta/prev.
-    factor = if prev.total_memory > 0, do: curr.total_memory / prev.total_memory, else: 0
+    factor = growth_factor(prev.total_memory, curr.total_memory)
 
     cond do
       # An ordinary-sized heap never bloats on ratio alone.
       curr.total_memory < @min_notable_bytes -> []
+      # A flat or shrinking transition isn't growth, even at a large size.
+      not growth?(factor) -> []
       critical_bloat?(prev, curr, delta, stats) -> [bloat_finding(:critical, prev, curr, factor, delta)]
       warning_bloat?(prev, delta, stats) -> [bloat_finding(:warning, prev, curr, factor, delta)]
       true -> []
     end
   end
+
+  # curr/prev, with sentinels for the (near-impossible) zero-previous case.
+  defp growth_factor(prev, curr) when prev > 0, do: curr / prev
+  defp growth_factor(_prev, curr) when curr > 0, do: :infinity
+  defp growth_factor(_prev, _curr), do: 1.0
+
+  defp growth?(:infinity), do: true
+  defp growth?(factor), do: factor >= @min_growth_factor
 
   # Critical: 10x growth, or 10x median delta, or beyond mean + 2 std_dev.
   defp critical_bloat?(prev, curr, delta, stats) do
@@ -179,7 +195,7 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Memory do
       message:
         "Memory grew #{format_multiplier(factor)}x between events (#{format_bytes(prev.total_memory)} → #{format_bytes(curr.total_memory)})",
       events: [prev.sequence, curr.sequence],
-      metadata: %{growth_multiplier: Float.round(factor, 1), delta_bytes: delta}
+      metadata: %{growth_multiplier: format_multiplier(factor), delta_bytes: delta}
     }
   end
 
@@ -229,6 +245,7 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Memory do
     end
   end
 
+  defp format_multiplier(:infinity), do: "∞"
   defp format_multiplier(mult) when mult >= 1, do: Float.round(mult, 1)
   defp format_multiplier(mult), do: Float.round(mult, 2)
 

--- a/lib/telemetry_capture/analyzers/message_flooding.ex
+++ b/lib/telemetry_capture/analyzers/message_flooding.ex
@@ -5,6 +5,14 @@ defmodule Excessibility.TelemetryCapture.Analyzers.MessageFlooding do
   LiveViews subscribing to PubSub or using timers can receive messages
   faster than useful, causing unnecessary processing and renders.
 
+  > #### Opt-in {: .warning}
+  >
+  > This analyzer reads `handle_info:*` timeline events, but Phoenix LiveView
+  > does not emit `handle_info` telemetry and the capture layer does not hook
+  > it, so nothing populates those events yet (issue #147). It is therefore
+  > **not** in the default set — enabling it would imply working coverage
+  > while staying silent. Enable it explicitly once handle_info capture lands.
+
   ## Detection
 
   - Sliding window: >10 same-name handle_info events within 200ms
@@ -31,7 +39,8 @@ defmodule Excessibility.TelemetryCapture.Analyzers.MessageFlooding do
   @total_threshold 20
 
   def name, do: :message_flooding
-  def default_enabled?, do: true
+  # Opt-in until the capture layer emits handle_info events (issue #147).
+  def default_enabled?, do: false
   def requires_enrichers, do: []
 
   def analyze(%{timeline: []}, _opts), do: %{findings: [], stats: %{}}

--- a/lib/telemetry_capture/analyzers/performance.ex
+++ b/lib/telemetry_capture/analyzers/performance.ex
@@ -5,17 +5,33 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Performance do
   Detects:
   - Slow events using adaptive thresholds (> mean + 2std_dev)
   - Bottlenecks (events taking >50% of total time)
-  - Very slow events (>1000ms)
+  - Very slow events (over an absolute ceiling, 1000ms by default)
 
   Uses data from the Duration enricher (event_duration_ms) to identify
   performance issues.
+
+  ## What this does *not* catch
+
+  This is a **relative** signal, not a latency budget. Findings fire on
+  outliers (an event much slower than the rest of the run), on the single
+  event that dominates total time, and on anything over the absolute ceiling.
+  **Uniformly slow code is invisible to it:** if every event takes a sluggish
+  400ms, nothing is an outlier, nothing dominates the total, and nothing
+  crosses the ceiling — so the section stays green.
+
+  That is deliberate. These durations come from a test run (ExUnit +
+  `Ecto.Sandbox` + cold first-mounts), so absolute timings are unreliable and
+  an absolute per-event threshold would mostly flag a slow CI box. Treat a
+  green performance section as "no relative regression in this run", not as
+  "fast". If your test timings are representative and you want an absolute
+  budget, lower the ceiling with `config :excessibility, slow_event_ms: 400`.
 
   ## Algorithm
 
   1. Calculate baseline stats (mean, std deviation)
   2. Detect slow events:
      - Warning: Duration > mean + 2std_dev
-     - Critical: Duration > 1000ms OR > mean + 3std_dev
+     - Critical: Duration > `:slow_event_ms` (default 1000ms) OR > mean + 3std_dev
   3. Detect bottlenecks: Events taking >50% of total time
 
   ## Output
@@ -50,6 +66,12 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Performance do
   # (>1000 ms) still escalate on their own.
   @min_notable_ms 100
 
+  # The absolute "very slow" ceiling: an event over this fires regardless of
+  # how the rest of the run looks, so uniformly-slow-but-representative code
+  # can be caught by lowering it (issue: performance is otherwise a relative
+  # signal). Default 1000ms; override with `config :excessibility, slow_event_ms: 400`.
+  @default_slow_event_ms 1000
+
   def name, do: :performance
   def default_enabled?, do: true
   def requires_enrichers, do: [:duration]
@@ -58,14 +80,14 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Performance do
     %{findings: [], stats: %{}}
   end
 
-  def analyze(%{timeline: timeline}, _opts) do
+  def analyze(%{timeline: timeline}, opts) do
     durations = extract_durations(timeline)
 
     if Enum.empty?(durations) do
       %{findings: [], stats: %{}}
     else
       stats = calculate_stats(durations)
-      findings = detect_issues(timeline, stats)
+      findings = detect_issues(timeline, stats, opts)
 
       %{
         findings: findings,
@@ -112,26 +134,32 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Performance do
     :math.sqrt(variance)
   end
 
-  defp detect_issues(timeline, stats) do
-    slow_findings = detect_slow_events(timeline, stats)
+  defp detect_issues(timeline, stats, opts) do
+    slow_findings = detect_slow_events(timeline, stats, slow_event_ms(opts))
     bottleneck_findings = detect_bottlenecks(timeline, stats)
 
     slow_findings ++ bottleneck_findings
   end
 
-  defp detect_slow_events(timeline, stats) do
+  # The absolute ceiling, from opts first (hermetic for callers/tests) then
+  # config (`config :excessibility, slow_event_ms: 400`), default 1000ms.
+  defp slow_event_ms(opts) do
+    Keyword.get(opts, :slow_event_ms) || Application.get_env(:excessibility, :slow_event_ms, @default_slow_event_ms)
+  end
+
+  defp detect_slow_events(timeline, stats, slow_ms) do
     threshold_warning = stats.avg_duration + 2 * stats.std_dev
     threshold_critical = stats.avg_duration + 3 * stats.std_dev
 
     Enum.flat_map(timeline, fn event ->
-      check_event_duration(event, stats, threshold_warning, threshold_critical)
+      check_event_duration(event, stats, threshold_warning, threshold_critical, slow_ms)
     end)
 
-    # Critical: >1000ms OR > mean + 3std_dev
+    # Critical: over the absolute ceiling (:slow_event_ms) OR > mean + 3std_dev
     # Warning: > mean + 2std_dev
   end
 
-  defp check_event_duration(event, stats, threshold_warning, threshold_critical) do
+  defp check_event_duration(event, stats, threshold_warning, threshold_critical, slow_ms) do
     duration = Map.get(event, :event_duration_ms)
 
     if is_nil(duration) do
@@ -142,7 +170,7 @@ defmodule Excessibility.TelemetryCapture.Analyzers.Performance do
 
       cond do
         # A genuinely slow event escalates regardless of the rest of the run.
-        duration > 1000 ->
+        duration > slow_ms ->
           [
             %{
               severity: :critical,

--- a/lib/telemetry_capture/enrichers/ecto_queries.ex
+++ b/lib/telemetry_capture/enrichers/ecto_queries.ex
@@ -82,21 +82,29 @@ defmodule Excessibility.TelemetryCapture.Enrichers.EctoQueries do
   end
 
   defp handle_query_event(_event, measurements, metadata, _config) do
+    record_query(build_query_record(measurements, metadata))
+  end
+
+  @doc """
+  Builds a normalized query record from an Ecto `[..., :query]` telemetry
+  event's measurements and metadata. Shared so the live capture layer
+  (`Excessibility.TelemetryCapture`) attributes queries to events using the
+  same shape this enricher reads back.
+  """
+  def build_query_record(measurements, metadata) do
     duration_ms =
       case Map.get(measurements, :total_time) do
         nil -> 0.0
         native -> System.convert_time_unit(native, :native, :microsecond) / 1000
       end
 
-    query_record = %{
+    %{
       source: Map.get(metadata, :source, "unknown"),
       operation: extract_operation(Map.get(metadata, :query, "")),
       duration_ms: Float.round(duration_ms, 2),
       query: Map.get(metadata, :query, ""),
       repo: Map.get(metadata, :repo)
     }
-
-    record_query(query_record)
   end
 
   defp extract_operation(query) when is_binary(query) do

--- a/lib/telemetry_capture/timeline.ex
+++ b/lib/telemetry_capture/timeline.ex
@@ -155,9 +155,14 @@ defmodule Excessibility.TelemetryCapture.Timeline do
         enrichers
       end
 
-    # Pass measurements through opts for enrichers that need them
+    # Pass measurements and captured Ecto queries through opts for enrichers
+    # that need them (the ecto_queries enricher attributes queries per event).
     measurements = Map.get(snapshot, :measurements, %{})
-    enricher_opts = Keyword.put(opts, :measurements, measurements)
+
+    enricher_opts =
+      opts
+      |> Keyword.put(:measurements, measurements)
+      |> Keyword.put(:ecto_queries, Map.get(snapshot, :ecto_queries, []))
 
     Enum.reduce(enrichers, %{}, fn enricher, acc ->
       enrichment = enricher.enrich(assigns, enricher_opts)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Excessibility.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/lessthanseventy/excessibility"
-  @version "0.16.0"
+  @version "0.17.0"
 
   def project do
     [

--- a/test/telemetry_capture/analyzers/memory_test.exs
+++ b/test/telemetry_capture/analyzers/memory_test.exs
@@ -68,6 +68,25 @@ defmodule Excessibility.TelemetryCapture.Analyzers.MemoryTest do
       assert Enum.any?(result.findings, &String.contains?(&1.message, "leak"))
     end
 
+    test "a flat plateau at a large size is not growth (issue #146)" do
+      # A run of small events that jumps once to ~300 KB and then holds steady.
+      # The jump (events 10->11) is a real finding; the flat 300 KB -> 300 KB
+      # transition must not be reported as "grew 1.0x" just because 300 KB is a
+      # global outlier that clears the absolute floor.
+      timeline = build_timeline(List.duplicate(1_000, 10) ++ [300_000, 300_000])
+      result = Memory.analyze(timeline, [])
+
+      # The real jump is still flagged.
+      assert Enum.any?(result.findings, &(&1.events == [10, 11]))
+
+      # No finding describes a flat transition.
+      refute Enum.any?(result.findings, &String.contains?(&1.message, "grew 1.0x")),
+             "flat plateau reported as growth: #{inspect(Enum.map(result.findings, & &1.message))}"
+
+      refute Enum.any?(result.findings, &(&1.events == [11, 12])),
+             "flat transition flagged: #{inspect(result.findings)}"
+    end
+
     test "handles single event timeline" do
       timeline = build_timeline([1000])
       result = Memory.analyze(timeline, [])

--- a/test/telemetry_capture/analyzers/message_flooding_test.exs
+++ b/test/telemetry_capture/analyzers/message_flooding_test.exs
@@ -10,8 +10,8 @@ defmodule Excessibility.TelemetryCapture.Analyzers.MessageFloodingTest do
   end
 
   describe "default_enabled?/0" do
-    test "returns true" do
-      assert MessageFlooding.default_enabled?() == true
+    test "returns false — opt-in until handle_info capture lands (issue #147)" do
+      assert MessageFlooding.default_enabled?() == false
     end
   end
 

--- a/test/telemetry_capture/analyzers/performance_test.exs
+++ b/test/telemetry_capture/analyzers/performance_test.exs
@@ -110,6 +110,38 @@ defmodule Excessibility.TelemetryCapture.Analyzers.PerformanceTest do
       assert result.stats == %{}
     end
 
+    test "uniformly slow code is invisible by default (relative signal, not a budget)" do
+      # Every event is a sluggish 400ms: no outlier, no bottleneck, and none
+      # crosses the default 1000ms ceiling — so nothing fires.
+      timeline = %{
+        timeline: [
+          %{sequence: 1, event: "mount", event_duration_ms: 400},
+          %{sequence: 2, event: "handle_event", event_duration_ms: 400},
+          %{sequence: 3, event: "handle_event", event_duration_ms: 400},
+          %{sequence: 4, event: "handle_event", event_duration_ms: 400}
+        ]
+      }
+
+      assert Performance.analyze(timeline, []).findings == []
+    end
+
+    test "lowering the ceiling catches uniformly slow code" do
+      timeline = %{
+        timeline: [
+          %{sequence: 1, event: "mount", event_duration_ms: 400},
+          %{sequence: 2, event: "handle_event", event_duration_ms: 400},
+          %{sequence: 3, event: "handle_event", event_duration_ms: 400},
+          %{sequence: 4, event: "handle_event", event_duration_ms: 400}
+        ]
+      }
+
+      # :slow_event_ms comes from opts (or `config :excessibility, slow_event_ms`).
+      result = Performance.analyze(timeline, slow_event_ms: 300)
+
+      assert Enum.count(result.findings, &(&1.severity == :critical)) == 4
+      assert Enum.all?(result.findings, &(&1.message =~ "Very slow event"))
+    end
+
     test "handles timeline without duration data" do
       timeline = %{
         timeline: [

--- a/test/telemetry_capture/ecto_capture_test.exs
+++ b/test/telemetry_capture/ecto_capture_test.exs
@@ -1,0 +1,113 @@
+defmodule Excessibility.TelemetryCapture.EctoCaptureTest do
+  @moduledoc """
+  Issue #147: the Ecto capture layer must actually record queries so
+  `ecto_query_analysis` can fire. These exercise the real telemetry path —
+  the same `[..., :query]` event Ecto emits — end to end, without a database.
+  """
+  # Not async: mutates application env and attaches global telemetry handlers.
+  use ExUnit.Case
+
+  alias Excessibility.TelemetryCapture
+  alias Excessibility.TelemetryCapture.Timeline
+
+  defmodule DerivedRepo do
+    @moduledoc false
+    # No config/0 — the query event is derived from the module name.
+  end
+
+  defmodule PrefixedRepo do
+    @moduledoc false
+    def config, do: [telemetry_prefix: [:my_app, :repo]]
+  end
+
+  setup do
+    on_exit(fn ->
+      Application.delete_env(:excessibility, :ecto_repos)
+      TelemetryCapture.detach()
+      TelemetryCapture.flush_ecto_queries()
+    end)
+
+    :ok
+  end
+
+  defp emit_query(event, source, query) do
+    :telemetry.execute(
+      event,
+      %{total_time: System.convert_time_unit(2, :millisecond, :native)},
+      %{source: source, query: query, repo: nil}
+    )
+  end
+
+  test "derives a repo's query event from its module name" do
+    Application.put_env(:excessibility, :ecto_repos, [DerivedRepo])
+
+    assert TelemetryCapture.ecto_query_events() == [
+             [:excessibility, :telemetry_capture, :ecto_capture_test, :derived_repo, :query]
+           ]
+  end
+
+  test "honors a repo's custom :telemetry_prefix" do
+    Application.put_env(:excessibility, :ecto_repos, [PrefixedRepo])
+
+    assert TelemetryCapture.ecto_query_events() == [[:my_app, :repo, :query]]
+  end
+
+  test "captures queries emitted at the configured repo's event, oldest first, then flushes" do
+    Application.put_env(:excessibility, :ecto_repos, [PrefixedRepo])
+    TelemetryCapture.attach()
+    on_exit(&TelemetryCapture.detach/0)
+
+    emit_query([:my_app, :repo, :query], "products", "SELECT * FROM products")
+    emit_query([:my_app, :repo, :query], "products", "SELECT * FROM products WHERE id = 1")
+
+    queries = TelemetryCapture.flush_ecto_queries()
+
+    assert length(queries) == 2
+    assert Enum.map(queries, & &1.source) == ["products", "products"]
+    assert hd(queries).operation == :select
+    assert hd(queries).duration_ms == 2.0
+
+    # A flush clears the buffer so queries attribute to a single event.
+    assert TelemetryCapture.flush_ecto_queries() == []
+  end
+
+  test "no handler is attached (and nothing captured) when no repos are configured" do
+    TelemetryCapture.attach()
+    on_exit(&TelemetryCapture.detach/0)
+
+    assert TelemetryCapture.ecto_query_events() == []
+    # An unrelated Ecto event fires but nothing listens for it.
+    emit_query([:some_other, :repo, :query], "x", "SELECT 1")
+    assert TelemetryCapture.flush_ecto_queries() == []
+  end
+
+  test "the timeline attributes captured queries to their event (enricher wiring)" do
+    n_plus_one =
+      for _ <- 1..15,
+          do: %{source: "products", operation: :select, duration_ms: 1.0, query: "SELECT", repo: nil}
+
+    snapshots = [
+      %{
+        event_type: "mount",
+        assigns: %{},
+        timestamp: DateTime.utc_now(),
+        view_module: SomeView,
+        ecto_queries: []
+      },
+      %{
+        event_type: "handle_event:load",
+        assigns: %{},
+        timestamp: DateTime.utc_now(),
+        view_module: SomeView,
+        ecto_queries: n_plus_one
+      }
+    ]
+
+    timeline = Timeline.build_timeline(snapshots, "t", [])
+    [mount_event, load_event] = timeline.timeline
+
+    assert mount_event.ecto_query_count == 0
+    assert load_event.ecto_query_count == 15
+    assert load_event.ecto_total_query_ms == 15.0
+  end
+end


### PR DESCRIPTION
Closes #146. Closes #147.

Includes the `0.17.0` version bump.

## #146 — memory "grew 1.0x" on a flat plateau

The 0.16.0 absolute floor gated the *size* but not the *ratio*, so a run holding steady at 1.3 MB (a global outlier above the floor) was reported as `[serious] Memory grew 1.0x`. A bloat finding now also requires the ratio to clear a minimum — a flat or shrinking transition isn't growth, even at a large size. (The consecutive-growth leak path already required a strict increase, so a flat plateau never qualified there.)

## #147 — dead behavioral analyzers

Two default-enabled analyzers could never fire because the capture layer never recorded their data.

- **Ecto queries are now captured.** `ecto_query_analysis` reads `ecto_queries`/`ecto_query_count`, but nothing populated them, so N+1 detection (the most common real LiveView perf defect) silently never ran. Capture now attaches to each configured repo's `[..., :query]` telemetry event, accumulates queries in the emitting process, and flushes them onto the LiveView event that ran them (per-event attribution). Enable with `config :excessibility, ecto_repos: [MyApp.Repo]`. When no repos are configured, capture logs that N+1 detection is off instead of reporting a green (empty) section.
- **`message_flooding` is retired to opt-in.** It reads `handle_info:*` events, but LiveView emits no `handle_info` telemetry and capture doesn't hook it, so it could never fire — enabling it implied working coverage while staying silent.

## Performance analyzer honesty (surfaced by a real run)

The performance analyzer is an **outlier** detector (event much slower than the run, event dominating total time, or one over an absolute ceiling), so **uniformly slow code — every event ~400 ms — is invisible to it.** That's deliberate: these are test timings (sandbox, cold mounts), not production latency, so an absolute per-event threshold would mostly flag a slow CI box. This PR documents that plainly (moduledoc/README/analysis docs) and makes the absolute "very slow" ceiling tunable — `config :excessibility, slow_event_ms: 400` — for teams whose timings are representative. Default unchanged (1000 ms).

## Validation

- Full suite green (803 tests), credo `--strict` clean, formatted.
- New tests: memory flat-plateau regression; Ecto capture exercised end-to-end via the real `[..., :query]` telemetry event (derivation, per-process accumulation, per-event attribution, enricher wiring) without a DB; performance uniformly-slow blind spot + configurable ceiling.
- **End-to-end against a real Phoenix app:** an N+1 LiveView (1 collection query + one per row) is now caught — `[serious] ecto_query_analysis: handle_event triggered 15 queries` — advisory by default (exit 0), gates with `--fail-on-behavioral` (exit 1); the healthy journey stays clean with `ecto_repos` configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)