### PR TITLE
Opt-in handle_info capture (revive message_flooding) + debug flag fixes, v0.18.0 (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-08-06
+
+### Added
+- **Opt-in `handle_info` capture, reviving `message_flooding`** ([#147](https://github.com/lessthanseventy/excessibility/issues/147)). Phoenix LiveView emits no `handle_info` telemetry, so there was nothing to attach to globally. `Excessibility.TelemetryCapture` now exports an `on_mount/4` hook that uses `Phoenix.LiveView.attach_hook/4` on the `:handle_info` stage to record each message as a `handle_info:<name>` timeline event. It is opt-in — wire it where you want it, e.g. one line on a router `live_session`: `live_session :default, on_mount: [Excessibility.TelemetryCapture]`. It attaches nothing unless telemetry capture is running and the socket is connected, so it is safe in all environments. Pair it with the (still opt-in) `message_flooding` analyzer.
+
+### Fixed
+- **`message_flooding` no longer crashes on a captured timeline** ([#147](https://github.com/lessthanseventy/excessibility/issues/147)). Its sliding window called `DateTime.diff` on `event.timestamp`, but a timeline read back from `timeline.json` has no `%DateTime{}` — timestamps serialize to a struct-map that does not round-trip. Timeline events now carry a JSON-safe numeric `timestamp_ms`, and the window uses it (falling back to a `%DateTime{}` when present, e.g. in-memory).
+- **`mix excessibility.debug --analyze` / `--no-analyze` / `--profile` are honored** ([#147](https://github.com/lessthanseventy/excessibility/issues/147)). These flags were dropped while building the internal filter options, so analyzer selection silently always fell back to the default set — which is why enabling an opt-in analyzer (or `--analyze=all`) appeared to do nothing.
+
+
 ## [0.17.0] - 2026-08-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ This generates `timeline.json` with event flow, memory usage, and pattern analys
 - `cascade_effect` - Detects rapid event cascades (use `--analyze=cascade_effect`)
 - `hypothesis` - Root cause suggestions (use `--analyze=hypothesis`)
 - `code_pointer` - Maps events to source locations (use `--analyze=code_pointer`)
-- `message_flooding` - Detects high-frequency handle_info patterns (dormant: LiveView emits no handle_info telemetry yet, use `--analyze=message_flooding`)
+- `message_flooding` - Detects high-frequency handle_info patterns (needs the opt-in `on_mount Excessibility.TelemetryCapture` hook, then `--analyze=message_flooding`)
 - `accessibility_correlation` - Flags state changes with a11y implications (use `--analyze=accessibility_correlation`)
 - `component_rerender` - Detects unnecessary component re-renders (use `--analyze=component_rerender`)
 - `push_event_volume` - Detects excessive push_event volume to JS hooks (use `--analyze=push_event_volume`)

--- a/README.md
+++ b/README.md
@@ -593,6 +593,22 @@ mix excessibility.review --timeline test/excessibility/timeline.json --fail-on-b
 
 The analyzers group events by LiveView before comparing, so a journey test that drives several LiveViews doesn't produce cross-view artifacts (a freshly-mounted view sitting next to a loaded one is not "memory growth").
 
+Two signals are opt-in because they need extra wiring:
+
+- **N+1 / query analysis** needs `config :excessibility, ecto_repos: [MyApp.Repo]` (capture attaches to the repo's query telemetry).
+- **`handle_info` flooding** needs the `on_mount` hook (LiveView emits no `handle_info` telemetry). Add it once to a `live_session`, then enable the analyzer:
+
+  ```elixir
+  # router.ex
+  live_session :default, on_mount: [Excessibility.TelemetryCapture] do
+    # ...your live routes...
+  end
+  ```
+
+  ```bash
+  mix excessibility.debug test/my_test.exs --analyze=message_flooding
+  ```
+
 ## Configuration
 
 All configuration goes in `test/test_helper.exs` or `config/test.exs`:

--- a/docs/telemetry-analysis.md
+++ b/docs/telemetry-analysis.md
@@ -66,8 +66,12 @@ each event ran. Capture attaches to each configured repo's `[..., :query]`
 telemetry event and attributes queries to the in-flight LiveView event — set
 `config :excessibility, ecto_repos: [MyApp.Repo]` to enable it. Without it,
 capture logs that N+1 detection is off rather than reporting an empty section.
-`message_flooding` is dormant (opt-in) until the capture layer emits
-`handle_info` events, which LiveView does not provide by default.
+`message_flooding` (handle_info floods) needs the opt-in
+`Excessibility.TelemetryCapture` `on_mount` hook — LiveView emits no
+`handle_info` telemetry, so the hook (`attach_hook/4` on the `:handle_info`
+stage) is the seam. Wire it in one line on a router `live_session`:
+`live_session :default, on_mount: [Excessibility.TelemetryCapture]`, then
+enable the analyzer with `--analyze=message_flooding`.
 
 **Example:**
 ```elixir

--- a/lib/mix/tasks/excessibility_debug.ex
+++ b/lib/mix/tasks/excessibility_debug.ex
@@ -159,6 +159,11 @@ defmodule Mix.Tasks.Excessibility.Debug do
         ]
       end
 
+    # Carry the analyzer-selection flags through: parse_analyzer_selection reads
+    # these off filter_opts, so without them --analyze/--no-analyze/--profile
+    # are silently ignored and the run always falls back to the default set.
+    filter_opts = Keyword.merge(filter_opts, Keyword.take(opts, [:analyze, :no_analyze, :profile]))
+
     # Parse highlight fields if provided
     case Keyword.get(opts, :highlight) do
       nil ->

--- a/lib/telemetry_capture.ex
+++ b/lib/telemetry_capture.ex
@@ -124,6 +124,70 @@ defmodule Excessibility.TelemetryCapture do
     queries
   end
 
+  @handle_info_hook_id :excessibility_handle_info
+
+  @doc """
+  An **opt-in** `on_mount` hook that records a LiveView's `handle_info`
+  messages as timeline events.
+
+  Phoenix LiveView emits telemetry for `mount`/`handle_params`/`handle_event`/
+  `render` but not for the message-driven callbacks, so there is no global
+  event to attach to (issue #147). This hook is the seam: it uses
+  `Phoenix.LiveView.attach_hook/4` on the `:handle_info` stage, which does
+  need to be installed per LiveView — so it is opt-in, never forced.
+
+  Wire it wherever you want that coverage — a router `live_session` covers
+  every route in the session in one line:
+
+      live_session :default, on_mount: [Excessibility.TelemetryCapture] do
+        # ...routes...
+      end
+
+  or your web module's `live_view/0` to cover every LiveView. It attaches
+  nothing unless telemetry capture is running (`mix excessibility.debug`) and
+  the socket is connected, so it is safe to leave wired in all environments.
+  Pair it with the (also opt-in) `message_flooding` analyzer.
+  """
+  def on_mount(_name, _params, _session, socket) do
+    if capture_running?() and Phoenix.LiveView.connected?(socket) do
+      {:cont, Phoenix.LiveView.attach_hook(socket, @handle_info_hook_id, :handle_info, &handle_info_hook/2)}
+    else
+      {:cont, socket}
+    end
+  end
+
+  defp capture_running? do
+    System.get_env("EXCESSIBILITY_TELEMETRY_CAPTURE") == "true"
+  end
+
+  # Runs before the LiveView's own handle_info (so assigns are pre-callback,
+  # which is fine — message_flooding cares about the event, not the state).
+  defp handle_info_hook(message, socket) do
+    record_handle_info(message, socket)
+    {:cont, socket}
+  end
+
+  defp record_handle_info(message, socket) do
+    clean_assigns = extract_clean_assigns(socket)
+    view_module = extract_view_module(socket, %{})
+    store_snapshot("handle_info:#{message_name(message)}", clean_assigns, view_module, %{}, %{}, flush_ecto_queries())
+  rescue
+    error -> Logger.warning("Excessibility: failed to record handle_info: #{inspect(error)}")
+  end
+
+  # A stable, low-cardinality name for grouping: the atom, or a tagged tuple's
+  # tag (`{:tick, _}` -> `tick`); anything else collapses to "message".
+  defp message_name(message) when is_atom(message), do: message
+
+  defp message_name(message) when is_tuple(message) and tuple_size(message) > 0 do
+    case elem(message, 0) do
+      tag when is_atom(tag) -> tag
+      _ -> "message"
+    end
+  end
+
+  defp message_name(_message), do: "message"
+
   @doc """
   Handles telemetry events and captures snapshots.
   """

--- a/lib/telemetry_capture/analyzers/message_flooding.ex
+++ b/lib/telemetry_capture/analyzers/message_flooding.ex
@@ -7,11 +7,14 @@ defmodule Excessibility.TelemetryCapture.Analyzers.MessageFlooding do
 
   > #### Opt-in {: .warning}
   >
-  > This analyzer reads `handle_info:*` timeline events, but Phoenix LiveView
-  > does not emit `handle_info` telemetry and the capture layer does not hook
-  > it, so nothing populates those events yet (issue #147). It is therefore
-  > **not** in the default set — enabling it would imply working coverage
-  > while staying silent. Enable it explicitly once handle_info capture lands.
+  > This analyzer reads `handle_info:*` timeline events. Phoenix LiveView emits
+  > no `handle_info` telemetry, so those events are only captured when you opt
+  > into the `Excessibility.TelemetryCapture` `on_mount` hook (issue #147) —
+  > e.g. `live_session :default, on_mount: [Excessibility.TelemetryCapture]`.
+  > Because that wiring is opt-in, the analyzer is **not** in the default set
+  > (a default-on analyzer with no hook would imply coverage while staying
+  > silent). Enable it explicitly (`--analyze=message_flooding` or via config)
+  > once the hook is wired.
 
   ## Detection
 
@@ -39,7 +42,7 @@ defmodule Excessibility.TelemetryCapture.Analyzers.MessageFlooding do
   @total_threshold 20
 
   def name, do: :message_flooding
-  # Opt-in until the capture layer emits handle_info events (issue #147).
+  # Opt-in: needs the (opt-in) TelemetryCapture on_mount hook to have data (#147).
   def default_enabled?, do: false
   def requires_enrichers, do: []
 
@@ -75,11 +78,9 @@ defmodule Excessibility.TelemetryCapture.Analyzers.MessageFlooding do
     events
     |> Enum.chunk_every(@window_threshold, 1, :discard)
     |> Enum.flat_map(fn window ->
-      first_ts = List.first(window).timestamp
-      last_ts = List.last(window).timestamp
-      span_ms = DateTime.diff(last_ts, first_ts, :millisecond)
+      span_ms = window_span_ms(window)
 
-      if span_ms <= @window_ms do
+      if span_ms && span_ms <= @window_ms do
         sequences = Enum.map(window, & &1.sequence)
         info_name = String.replace_prefix(event_type, "handle_info:", "")
 
@@ -102,6 +103,25 @@ defmodule Excessibility.TelemetryCapture.Analyzers.MessageFlooding do
     end)
     |> Enum.take(1)
   end
+
+  # Wall-clock span of a window, using the JSON-safe epoch-ms time. Falls back
+  # to a %DateTime{} timestamp (in-memory timelines and tests); nil if neither
+  # is available, in which case the window is skipped rather than crashing.
+  defp window_span_ms(window) do
+    first_ms = event_ms(List.first(window))
+    last_ms = event_ms(List.last(window))
+    if first_ms && last_ms, do: last_ms - first_ms
+  end
+
+  defp event_ms(event) do
+    case Map.get(event, :timestamp_ms) do
+      ms when is_integer(ms) -> ms
+      _ -> datetime_ms(Map.get(event, :timestamp))
+    end
+  end
+
+  defp datetime_ms(%DateTime{} = datetime), do: DateTime.to_unix(datetime, :millisecond)
+  defp datetime_ms(_), do: nil
 
   defp detect_total_flooding(events) do
     events

--- a/lib/telemetry_capture/timeline.ex
+++ b/lib/telemetry_capture/timeline.ex
@@ -120,6 +120,10 @@ defmodule Excessibility.TelemetryCapture.Timeline do
         sequence: sequence,
         event: snapshot.event_type,
         timestamp: snapshot.timestamp,
+        # A JSON-safe epoch-ms time: `timestamp` serializes to a struct-map
+        # that does not round-trip back into a %DateTime{}, so time-based
+        # analyzers (message_flooding) need a plain number to diff (issue #147).
+        timestamp_ms: DateTime.to_unix(snapshot.timestamp, :millisecond),
         view_module: snapshot.view_module,
         key_state: key_state,
         changes: changes,

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Excessibility.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/lessthanseventy/excessibility"
-  @version "0.17.0"
+  @version "0.18.0"
 
   def project do
     [

--- a/test/telemetry_capture/analyzers/message_flooding_test.exs
+++ b/test/telemetry_capture/analyzers/message_flooding_test.exs
@@ -49,6 +49,25 @@ defmodule Excessibility.TelemetryCapture.Analyzers.MessageFloodingTest do
       assert finding.message =~ "tick"
     end
 
+    test "uses the JSON-safe timestamp_ms without crashing (issue #147)" do
+      # A timeline loaded from timeline.json has no %DateTime{} — timestamps
+      # serialize to a struct-map that doesn't round-trip. The numeric
+      # timestamp_ms is what survives, and the sliding window must use it.
+      events =
+        for i <- 1..15 do
+          %{
+            sequence: i,
+            event: "handle_info:tick",
+            timestamp_ms: 1_700_000_000_000 + i * 5,
+            duration_since_previous_ms: 5
+          }
+        end
+
+      result = MessageFlooding.analyze(%{timeline: events}, [])
+
+      assert Enum.any?(result.findings, &(&1.message =~ "handle_info(:tick)"))
+    end
+
     test "detects excessive total count of handle_info events" do
       events =
         for i <- 1..25 do

--- a/test/telemetry_capture/handle_info_capture_test.exs
+++ b/test/telemetry_capture/handle_info_capture_test.exs
@@ -1,0 +1,30 @@
+defmodule Excessibility.TelemetryCapture.HandleInfoCaptureTest do
+  @moduledoc """
+  Issue #147: the opt-in `on_mount` hook records `handle_info` messages (which
+  have no LiveView telemetry) so `message_flooding` can fire. The full capture
+  path is exercised end-to-end against a real LiveView in the demo app; here we
+  pin the production-safety guarantee — the hook does nothing unless telemetry
+  capture is actually running.
+  """
+  use ExUnit.Case
+
+  alias Excessibility.TelemetryCapture
+
+  setup do
+    previous = System.get_env("EXCESSIBILITY_TELEMETRY_CAPTURE")
+    System.delete_env("EXCESSIBILITY_TELEMETRY_CAPTURE")
+
+    on_exit(fn ->
+      if previous, do: System.put_env("EXCESSIBILITY_TELEMETRY_CAPTURE", previous)
+    end)
+
+    :ok
+  end
+
+  test "on_mount attaches no hook and returns the socket untouched when capture is off" do
+    socket = %Phoenix.LiveView.Socket{}
+
+    assert {:cont, returned} = TelemetryCapture.on_mount(:default, %{}, %{}, socket)
+    assert returned == socket
+  end
+end


### PR DESCRIPTION
Follow-up to #148, closing out the `message_flooding` half of #147.

Includes the `0.18.0` version bump.

## Opt-in `handle_info` capture

Phoenix LiveView instruments `mount`/`handle_params`/`handle_event`/`render` with telemetry, but **not** the message-driven callbacks — so there's no global event to attach to for `handle_info`. `Excessibility.TelemetryCapture` now exports an `on_mount/4` hook that uses `Phoenix.LiveView.attach_hook/4` on the `:handle_info` stage to record each message as a `handle_info:<name>` timeline event.

It's **opt-in and low-friction** — one line on a router `live_session`:

```elixir
live_session :default, on_mount: [Excessibility.TelemetryCapture] do
  # ...your live routes...
end
```

It attaches nothing unless telemetry capture is running (`mix excessibility.debug`) and the socket is connected, so it's safe to leave wired in all environments. `message_flooding` stays opt-in (it needs the hook to have data), but it now actually works.

## Two bugs this surfaced

- **`message_flooding` crashed on every captured timeline.** Its sliding window called `DateTime.diff` on `event.timestamp`, but a timeline read back from `timeline.json` has no `%DateTime{}` — timestamps serialize to a struct-map (`calendar` becomes the string `"Elixir.Calendar.ISO"`) that doesn't round-trip. Timeline events now carry a JSON-safe numeric `timestamp_ms`, and the window uses it (falling back to `%DateTime{}` in-memory).
- **`mix excessibility.debug --analyze` / `--no-analyze` / `--profile` were silently ignored.** `build_filter_opts` dropped those keys before `parse_analyzer_selection` read them, so selection always fell back to the default set — which is why enabling an opt-in analyzer (or `--analyze=all`) did nothing.

## Validation

- Full suite green (805 tests), credo `--strict` clean, formatted.
- New tests: production-safety (hook is a no-op when capture is off); message_flooding on the JSON-safe `timestamp_ms` path.
- **End-to-end in a real Phoenix app:** a self-flooding LiveView (30 `:tick` messages) with the `on_mount` hook wired → `handle_info:tick` events are captured and `message_flooding` fires (`⚠️ 30 handle_info(:tick) events total`); `--analyze` now correctly restricts the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)