### PR TITLE
docs: bump README dependency example to ~> 0.18 (#160)

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Add to `mix.exs`:
 ```elixir
 def deps do
   [
-    {:excessibility, "~> 0.15", only: [:dev, :test]}
+    {:excessibility, "~> 0.18", only: [:dev, :test]}
   ]
 end
 ```


### PR DESCRIPTION
## Summary
The release `version-tag` workflow greps `README.md` for `{:excessibility, "~> <major.minor>"` matching `mix.exs`. The install example was stale at `~> 0.15`, failing the **Check README version** step and blocking the 0.18.1 tag/publish.

Bumps the single dependency example to `~> 0.18`. `mix.exs` (0.18.1) and `CHANGELOG.md` already agree.

Closes #160.

## Verification
Simulated the CI check locally:
```
MAJOR_MINOR=0.18; grep -q '{:excessibility, "~> 0.18"' README.md  # ✓ passes
```
Only one dep-style reference exists in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)