### PR TITLE
fix: strip SQL comments and validate fixture metadata in digest (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Privacy: strip SQL comments and validate fixture metadata in `digest.json`** ([#156](https://github.com/lessthanseventy/excessibility/issues/156)). `Excessibility.SQLFingerprint.normalize/1` now removes SQL line (`-- …`) and block (`/* … */`) comments before any value folding, using a literal-aware scanner so comment markers inside string/dollar-quoted literals or quoted identifiers are preserved rather than mistaken for comments. Comments no longer affect fingerprints (they never reach the normalized string), so grouping stays stable. `coverage.fixtures` is validated at the digest boundary — both the `EXCESSIBILITY_FIXTURES` env JSON and `config :excessibility, :fixtures` are reduced to string-key → non-negative-integer cardinalities; strings, floats, and nested maps/lists are dropped and their key names surfaced as a value-free `capture.warnings` entry. This closes two paths that could copy arbitrary application values into the "value-free" artifact.
+
 ### BREAKING
 - **`mix excessibility.compare` renamed to `mix excessibility.snapshot.compare`** ([#154](https://github.com/lessthanseventy/excessibility/issues/154)). The snapshot baseline-diff task moves under the `snapshot` namespace to make room for the new runtime-evidence digest tasks. There is no deprecated alias — update any scripts, CI steps, or editor tasks that call `mix excessibility.compare` (including `--keep good`/`--keep bad`) to `mix excessibility.snapshot.compare`. The task's behavior is unchanged.
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Position this as **supplemental** input for debugging and code-aware review. It 
 }
 ```
 
-**Privacy guarantee.** The digest **never** contains assign values, params/form values, user/session records, SQL bind values, rendered HTML, or arbitrary inspected terms. Every field is a name, a shape, a coarse size, a count, or a fingerprint. Redaction is by omission — if a field cannot be derived safely, it is left out, not guessed.
+**Privacy guarantee.** The digest **never** contains assign values, params/form values, user/session records, SQL bind values, SQL comment contents, rendered HTML, or arbitrary inspected terms. Every field is a name, a shape, a coarse size, a count, or a fingerprint. Redaction is by omission — if a field cannot be derived safely, it is left out, not guessed. Line and block comments are stripped from normalized SQL by a literal-aware scanner (comment markers inside string/dollar-quoted literals or quoted identifiers are preserved, not mistaken for comments), and `coverage.fixtures` is validated down to string-key → non-negative-integer cardinalities only — non-numeric or nested fixture values are dropped and their key names surfaced as a value-free `capture.warnings` entry.
 
 The **coverage/status contract** makes silence interpretable: an unexercised callback is simply absent from `callbacks_observed`; `ecto_configured: false` means "queries were not measured" (distinct from measured-and-zero); a disabled enricher or failed capture shows up in `enrichers_run` / `status` + `warnings`. A missing signal is always labeled *why*.
 
@@ -355,7 +355,7 @@ mix excessibility.debug --format digest test/my_live_view_test.exs
 
 ### Query fingerprints and N+1
 
-Every captured Ecto query is normalized into a stable, value-free SQL shape (`Excessibility.SQLFingerprint`): keywords downcased, `$1,$2 → $?`, `IN (...)` arity folded, inline numeric/quoted literals scrubbed to `?`, whitespace collapsed. A `sha256:` fingerprint is derived from that normalized string. N+1 evidence groups by **fingerprint** (via the shared `Excessibility.QueryEvidence`), so two *different* SELECTs on the same table are counted as two shapes rather than lumped together by table name. The normalizer is Postgres-oriented (the Ecto reference adapter emits parameterized SQL); other adapters still fingerprint via the generic regex.
+Every captured Ecto query is normalized into a stable, value-free SQL shape (`Excessibility.SQLFingerprint`): keywords downcased, line/block **comments stripped** (literal-aware, so a `--` or `/* */` inside a string or quoted identifier is left intact), `$1,$2 → $?`, `IN (...)` arity folded, inline numeric/quoted literals scrubbed to `?`, whitespace collapsed. A `sha256:` fingerprint is derived from that normalized string. N+1 evidence groups by **fingerprint** (via the shared `Excessibility.QueryEvidence`), so two *different* SELECTs on the same table are counted as two shapes rather than lumped together by table name. The normalizer is Postgres-oriented (the Ecto reference adapter emits parameterized SQL); other adapters still fingerprint via the generic regex.
 
 ### Opt-in query-plan (EXPLAIN) evidence — Postgres-only
 
@@ -749,7 +749,7 @@ All configuration goes in `test/test_helper.exs` or `config/test.exs`:
 | `:sql_dialect` | No | `:postgres` | SQL dialect for query normalization/EXPLAIN. Only `:postgres` ships today; the `Excessibility.Dialect` seam lets a new dialect drop in |
 | `:query_plan_allow_analyze` | No | `false` | Second gate for `--plan-analyze` (EXPLAIN ANALYZE, which executes queries). Enable only in a read-only DB sandbox |
 | `:digest_include_normalized_sql` | No | `true` | Include the normalized (value-free) SQL string in each digest query shape; set `false` to emit fingerprint-only |
-| `:fixtures` | No | `%{}` | Caller-supplied fixture cardinality surfaced in the digest's `coverage.fixtures` (also settable per-run via `EXCESSIBILITY_FIXTURES` JSON, which takes precedence) |
+| `:fixtures` | No | `%{}` | Caller-supplied fixture cardinality surfaced in the digest's `coverage.fixtures` (also settable per-run via `EXCESSIBILITY_FIXTURES` JSON, which takes precedence). Validated to string-key → non-negative-integer entries only; strings, floats, and nested maps/lists are dropped (rejected key names appear in `capture.warnings`) |
 
 ### Runtime digest environment variables
 
@@ -758,7 +758,7 @@ Set on `mix excessibility.debug` runs (the `--plan`/`--plan-analyze` flags set t
 | Env var | Purpose |
 |---------|---------|
 | `EXCESSIBILITY_QUERY_PLAN` | `explain` \| `explain_analyze` \| unset. Enables opt-in query-plan capture. `explain_analyze` still requires `:query_plan_allow_analyze`. |
-| `EXCESSIBILITY_FIXTURES` | JSON object of fixture cardinalities for `coverage.fixtures`. Takes precedence over `config :excessibility, :fixtures`; malformed JSON is ignored with a warning. |
+| `EXCESSIBILITY_FIXTURES` | JSON object of fixture cardinalities for `coverage.fixtures`. Takes precedence over `config :excessibility, :fixtures`; malformed JSON is ignored with a warning. Entries are validated to non-negative-integer cardinalities — string/nested values are dropped, never copied into the digest. |
 
 Example:
 

--- a/lib/excessibility/digest.ex
+++ b/lib/excessibility/digest.ex
@@ -29,11 +29,13 @@ defmodule Excessibility.Digest do
   """
   def build(timeline, opts \\ []) do
     events = Map.get(timeline, :timeline, [])
+    {fixtures, fixture_warnings} = sanitize_fixtures(Keyword.get(opts, :fixtures, %{}))
+    warnings = Keyword.get(opts, :warnings, []) ++ fixture_warnings
 
     %{
       schema: @schema_version,
-      capture: capture_block(opts),
-      coverage: coverage_block(timeline, events, opts),
+      capture: capture_block(opts, warnings),
+      coverage: coverage_block(timeline, events, fixtures),
       events: build_events(events),
       trajectories: trajectories(events)
     }
@@ -56,7 +58,7 @@ defmodule Excessibility.Digest do
       }
   end
 
-  defp capture_block(opts) do
+  defp capture_block(opts, warnings) do
     %{
       status: :ok,
       ecto_configured: Keyword.get(opts, :ecto_configured?, false),
@@ -65,12 +67,13 @@ defmodule Excessibility.Digest do
       timing: :non_comparable,
       capture_version: capture_version(),
       # Plan-capture warnings accumulate in the LiveView process during EXPLAIN
-      # and are threaded here via `:warnings` (see TelemetryCapture.write_snapshots/1).
-      warnings: Keyword.get(opts, :warnings, [])
+      # and are threaded here via `:warnings`; fixture-validation warnings are
+      # appended by build/2 (see TelemetryCapture.write_snapshots/1).
+      warnings: warnings
     }
   end
 
-  defp coverage_block(timeline, events, opts) do
+  defp coverage_block(timeline, events, fixtures) do
     callbacks = Enum.map(events, & &1.event)
 
     %{
@@ -78,9 +81,48 @@ defmodule Excessibility.Digest do
       views: events |> Enum.map(&view_name(&1.view_module)) |> Enum.uniq(),
       callbacks_observed: Enum.uniq(callbacks),
       event_sequence: callbacks,
-      fixtures: Keyword.get(opts, :fixtures, %{})
+      fixtures: fixtures
     }
   end
+
+  # `coverage.fixtures` is documented as cardinality metadata only. Enforce that
+  # contract here at the safe-by-construction boundary so *both* channels (the
+  # `EXCESSIBILITY_FIXTURES` env JSON and `config :excessibility, :fixtures`) are
+  # covered: keep only string/atom-keyed entries whose value is a non-negative
+  # integer, drop everything else, and surface the dropped *key names* (never the
+  # rejected values) in a value-free warning.
+  defp sanitize_fixtures(fixtures) when is_map(fixtures) do
+    {kept, dropped} =
+      Enum.reduce(fixtures, {%{}, []}, fn {key, value}, {kept, dropped} ->
+        name = to_string(key)
+
+        if valid_cardinality?(value) do
+          {Map.put(kept, name, value), dropped}
+        else
+          {kept, [name | dropped]}
+        end
+      end)
+
+    {kept, fixture_warnings(Enum.sort(dropped))}
+  end
+
+  defp sanitize_fixtures(_other) do
+    {%{}, ["coverage.fixtures ignored: value was not a JSON object / map"]}
+  end
+
+  defp valid_cardinality?(value), do: is_integer(value) and value >= 0
+
+  defp fixture_warnings([]), do: []
+
+  defp fixture_warnings(keys) do
+    [
+      "coverage.fixtures: dropped #{length(keys)} non-cardinality " <>
+        "#{entry_word(keys)} (values must be non-negative integers): #{Enum.join(keys, ", ")}"
+    ]
+  end
+
+  defp entry_word([_single]), do: "entry"
+  defp entry_word(_many), do: "entries"
 
   # Map events in original sequence order, threading each view's previous
   # `assign_sizes` so per-event byte deltas only compare within the same

--- a/lib/excessibility/sql_fingerprint.ex
+++ b/lib/excessibility/sql_fingerprint.ex
@@ -18,6 +18,7 @@ defmodule Excessibility.SQLFingerprint do
   def normalize(sql) when is_binary(sql) do
     sql
     |> String.downcase()
+    |> strip_comments()
     |> fold_dollar_quoted()
     |> fold_escape_strings()
     |> fold_quoted_literals()
@@ -41,6 +42,83 @@ defmodule Excessibility.SQLFingerprint do
       |> binary_part(0, 16)
 
     "sha256:" <> hash
+  end
+
+  # Remove SQL line (`-- …`) and block (`/* … */`) comments *before* any value
+  # folding, so comment contents (tracing annotations, tenant tags, etc.) never
+  # reach the digest. A single left-to-right scanner tracks literal/identifier
+  # context so a comment marker *inside* a string, dollar-quoted body, or quoted
+  # identifier is copied verbatim rather than mistaken for a comment start.
+  # Comments are replaced with a space to preserve token separation; the later
+  # whitespace collapse tidies up. Comment-free SQL is returned unchanged, so
+  # fingerprints stay stable and comments never affect grouping.
+  defp strip_comments(sql), do: scan(sql, :normal, "")
+
+  # End of input in any state.
+  defp scan(<<>>, _state, acc), do: acc
+
+  # --- line comment: drop everything up to (and re-emit) the newline ---
+  defp scan(<<"\n", rest::binary>>, :line, acc), do: scan(rest, :normal, <<acc::binary, "\n">>)
+  defp scan(<<_c, rest::binary>>, :line, acc), do: scan(rest, :line, acc)
+
+  # --- block comment: Postgres allows nesting, so track depth ---
+  defp scan(<<"/*", rest::binary>>, {:block, depth}, acc), do: scan(rest, {:block, depth + 1}, acc)
+  defp scan(<<"*/", rest::binary>>, {:block, 1}, acc), do: scan(rest, :normal, <<acc::binary, " ">>)
+  defp scan(<<"*/", rest::binary>>, {:block, depth}, acc), do: scan(rest, {:block, depth - 1}, acc)
+  defp scan(<<_c, rest::binary>>, {:block, _} = state, acc), do: scan(rest, state, acc)
+
+  # --- single-quoted string literal: copy verbatim, honour '' escape ---
+  defp scan(<<"''", rest::binary>>, :squote, acc), do: scan(rest, :squote, <<acc::binary, "''">>)
+  defp scan(<<"'", rest::binary>>, :squote, acc), do: scan(rest, :normal, <<acc::binary, "'">>)
+  defp scan(<<c, rest::binary>>, :squote, acc), do: scan(rest, :squote, <<acc::binary, c>>)
+
+  # --- double-quoted identifier: copy verbatim, honour "" escape ---
+  defp scan(<<"\"\"", rest::binary>>, :dquote, acc), do: scan(rest, :dquote, <<acc::binary, "\"\"">>)
+  defp scan(<<"\"", rest::binary>>, :dquote, acc), do: scan(rest, :normal, <<acc::binary, "\"">>)
+  defp scan(<<c, rest::binary>>, :dquote, acc), do: scan(rest, :dquote, <<acc::binary, c>>)
+
+  # --- normal SQL: recognise comment/literal/identifier starts ---
+  defp scan(<<"--", rest::binary>>, :normal, acc), do: scan(rest, :line, <<acc::binary, " ">>)
+  defp scan(<<"/*", rest::binary>>, :normal, acc), do: scan(rest, {:block, 1}, <<acc::binary, " ">>)
+  defp scan(<<"'", rest::binary>>, :normal, acc), do: scan(rest, :squote, <<acc::binary, "'">>)
+  defp scan(<<"\"", rest::binary>>, :normal, acc), do: scan(rest, :dquote, <<acc::binary, "\"">>)
+
+  defp scan(<<"$", rest::binary>> = bin, :normal, acc) do
+    # Copy a dollar-quoted body verbatim so `--`/`/*` inside it are not stripped.
+    # Ecto params ($1, $2 …) have no matching close tag, so take_dollar_quoted/1
+    # returns :error and the lone `$` is copied like any other byte.
+    case take_dollar_quoted(bin) do
+      {:ok, quoted, tail} -> scan(tail, :normal, <<acc::binary, quoted::binary>>)
+      :error -> scan(rest, :normal, <<acc::binary, "$">>)
+    end
+  end
+
+  defp scan(<<c, rest::binary>>, :normal, acc), do: scan(rest, :normal, <<acc::binary, c>>)
+
+  # Match a full `$tag$ … $tag$` span at the head of `bin` and return it verbatim
+  # with the remainder. Tag is `[a-z0-9_]*` (already downcased). Returns :error
+  # when the head is not a complete dollar-quoted literal (e.g. a `$1` param or an
+  # unterminated body).
+  defp take_dollar_quoted(bin) do
+    case Regex.run(~r/^\$[a-z0-9_]*\$/, bin) do
+      [open] ->
+        open_len = byte_size(open)
+        after_open = binary_part(bin, open_len, byte_size(bin) - open_len)
+
+        case :binary.match(after_open, open) do
+          {pos, _len} ->
+            span_len = open_len + pos + byte_size(open)
+            quoted = binary_part(bin, 0, span_len)
+            rest = binary_part(bin, span_len, byte_size(bin) - span_len)
+            {:ok, quoted, rest}
+
+          :nomatch ->
+            :error
+        end
+
+      nil ->
+        :error
+    end
   end
 
   # $$body$$ / $tag$body$tag$ -> ?   (run first: body is arbitrary, may contain quotes/newlines).

--- a/test/digest_test.exs
+++ b/test/digest_test.exs
@@ -228,6 +228,58 @@ defmodule Excessibility.DigestTest do
            }
   end
 
+  describe "fixture validation (privacy)" do
+    test "keeps only string-keyed non-negative integer cardinalities" do
+      d = Digest.build(timeline(), fixtures: %{"records" => 2, "orgs" => 0})
+      assert d.coverage.fixtures == %{"records" => 2, "orgs" => 0}
+      assert d.capture.warnings == []
+    end
+
+    test "drops string values and surfaces the rejected key names (not values)" do
+      d =
+        Digest.build(timeline(),
+          fixtures: %{"request_email" => "alice@example.com", "records" => 2}
+        )
+
+      assert d.coverage.fixtures == %{"records" => 2}
+      # The dropped value must never appear anywhere in the emitted digest.
+      refute Jason.encode!(d) =~ "alice@example.com"
+      # The rejected key name is surfaced as a value-free warning.
+      assert Enum.any?(d.capture.warnings, &(&1 =~ "request_email"))
+    end
+
+    test "drops nested maps and lists rather than copying them" do
+      d =
+        Digest.build(timeline(),
+          fixtures: %{
+            "nested" => %{"secret" => "s3cr3t"},
+            "list" => [1, 2, 3],
+            "count" => 5
+          }
+        )
+
+      assert d.coverage.fixtures == %{"count" => 5}
+      refute Jason.encode!(d) =~ "s3cr3t"
+    end
+
+    test "drops negative and non-integer numeric cardinalities" do
+      d = Digest.build(timeline(), fixtures: %{"neg" => -1, "float" => 2.5, "ok" => 3})
+      assert d.coverage.fixtures == %{"ok" => 3}
+    end
+
+    test "atom keys from config :fixtures are normalized to strings and validated" do
+      d = Digest.build(timeline(), fixtures: %{records: 4, leaky: "value"})
+      assert d.coverage.fixtures == %{"records" => 4}
+      refute Jason.encode!(d) =~ "\"value\""
+    end
+
+    test "a non-map fixtures value is ignored with a warning" do
+      d = Digest.build(timeline(), fixtures: "not a map")
+      assert d.coverage.fixtures == %{}
+      assert Enum.any?(d.capture.warnings, &(&1 =~ "fixtures"))
+    end
+  end
+
   # A module-atom view (as live capture produces) must be rendered without the
   # `Elixir.` prefix everywhere it becomes an output field.
   defp atom_view_timeline do

--- a/test/sql_fingerprint_test.exs
+++ b/test/sql_fingerprint_test.exs
@@ -83,5 +83,56 @@ defmodule Excessibility.SQLFingerprintTest do
       assert n =~ "users_2024"
       assert n =~ "t2"
     end
+
+    test "line comment content is removed" do
+      n = SQLFingerprint.normalize("SELECT * FROM users -- request_email=alice@example.com")
+      refute n =~ "request_email"
+      refute n =~ "alice"
+      refute n =~ "--"
+      assert n == "select * from users"
+    end
+
+    test "block comment content is removed" do
+      n = SQLFingerprint.normalize("SELECT * FROM users /* tenant=example secret=abc */ WHERE id = $1")
+      refute n =~ "tenant"
+      refute n =~ "secret"
+      refute n =~ "/*"
+      assert n == "select * from users where id = $?"
+    end
+
+    test "nested block comments are removed" do
+      n = SQLFingerprint.normalize("SELECT /* a /* b secret */ c */ 1")
+      refute n =~ "secret"
+      refute n =~ "*/"
+      assert n == "select ?"
+    end
+
+    test "comment markers inside single-quoted literals are not treated as comments" do
+      # The whole literal must fold to ? and nothing after it may be dropped.
+      assert SQLFingerprint.normalize("SELECT '-- not a comment' AS a, id FROM t") ==
+               "select ? as a, id from t"
+
+      assert SQLFingerprint.normalize("SELECT '/* not a comment */' AS a, id FROM t") ==
+               "select ? as a, id from t"
+    end
+
+    test "comment markers inside dollar-quoted literals are not treated as comments" do
+      assert SQLFingerprint.normalize("SELECT $$-- not a comment$$ AS a, id FROM t") ==
+               "select ? as a, id from t"
+    end
+
+    test "comment markers inside double-quoted identifiers are preserved as identifiers" do
+      n = SQLFingerprint.normalize(~S(SELECT "weird--col", id FROM t))
+      assert n =~ ~S("weird--col")
+      assert n =~ "id"
+    end
+
+    test "comments do not affect the fingerprint (stable grouping)" do
+      assert SQLFingerprint.fingerprint("SELECT * FROM users WHERE id = $1") ==
+               SQLFingerprint.fingerprint("SELECT * FROM users WHERE id = $1 -- trace=abc")
+
+      assert SQLFingerprint.fingerprint("SELECT * FROM users WHERE id = $1") ==
+               SQLFingerprint.fingerprint("SELECT /* hint */ * FROM users WHERE id = $1")
+    end
   end
 end


### PR DESCRIPTION
## Summary
The digest is documented as **value-free / safe by construction**, but two paths could copy arbitrary application values into it. Closes #156.

1. **SQL comments** survived `SQLFingerprint.normalize/1`, and the normalized string is included in the digest by default. Comments are a common tracing/annotation channel (tenant tags, request emails).
2. **`EXCESSIBILITY_FIXTURES` / `config :fixtures`** copied arbitrary JSON values straight into `coverage.fixtures`, despite the documented cardinality-only contract.

## Changes
- **Literal-aware comment scanner** in `normalize/1`: removes `-- …` and `/* … */` (with Postgres nested block comments) *before* any value folding. Comment markers inside single-quoted strings, dollar-quoted bodies, and double-quoted identifiers are copied verbatim, not treated as comments. Comment-free SQL is unchanged → **fingerprints stay stable** and comments no longer affect grouping.
- **Fixture sanitization** at the `Digest.build` safe-by-construction boundary (covers both env + config channels): keep only string/atom-keyed non-negative-integer cardinalities; drop strings, floats, nested maps/lists; surface dropped **key names** (never values) as a value-free `capture.warnings` entry.

## Acceptance criteria
- [x] Line and block comment contents cannot appear in `digest.json`
- [x] Comment markers inside SQL literals are handled safely (single-pass scanner)
- [x] `EXCESSIBILITY_FIXTURES` cannot place strings or arbitrary nested values in the digest
- [x] Config-based `:fixtures` follows the same validation (shared boundary)
- [x] Adversarial tests assert on the final emitted digest (`Jason.encode!`), not only helper output
- [x] Hash/fingerprint stable after comment removal
- [x] Documentation accurately states normalized SQL default (`digest_include_normalized_sql: true`)

## Verification
`mix test` → 925 tests, 0 failures. `mix format` + `mix credo --strict` clean. New tests in `test/sql_fingerprint_test.exs` (comment stripping, literal-safety, fingerprint stability) and `test/digest_test.exs` (fixture validation asserting on emitted digest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)