### PR TITLE
chore: verify release tag targets the release commit; prep 0.19.0 (#168)

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -47,12 +47,28 @@ jobs:
           fi
           echo "✓ README.md version matches: ~> $MAJOR_MINOR"
 
-      - name: Check if tag already exists
+      - name: Check tag target consistency
         id: tag_check
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            echo "Tag v$VERSION already exists, skipping tag creation"
+          HEAD_SHA=$(git rev-parse HEAD)
+
+          if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            # Peel the tag (annotated or lightweight) to the commit it targets.
+            TAG_SHA=$(git rev-parse "v$VERSION^{commit}")
+            echo "Tag v$VERSION exists, targeting $TAG_SHA (release commit is $HEAD_SHA)"
+
+            # Existence alone is NOT success: if the tag does not point at the
+            # release commit, the source version was never bumped after v$VERSION
+            # was published, so main has diverged from the released package while
+            # still declaring an already-published version. Fail loudly.
+            if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+              echo "::error::Tag v$VERSION already exists but targets $TAG_SHA, not the release commit $HEAD_SHA."
+              echo "main has diverged from the published v$VERSION. Bump @version in mix.exs (and the README dependency example) to a new, unpublished version before merging."
+              exit 1
+            fi
+
+            echo "✓ Tag v$VERSION already targets the release commit; nothing to do."
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "Tag v$VERSION does not exist, will create"
@@ -68,9 +84,3 @@ jobs:
           git tag -a "v$VERSION" -m "Release v$VERSION"
           git push origin "v$VERSION"
           echo "✓ Created and pushed tag: v$VERSION"
-
-      - name: Tag already exists
-        if: steps.tag_check.outputs.exists == 'true'
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          echo "ℹ Tag v$VERSION already exists, no action taken"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-08-10
+
 ### Added
 - **Plan evidence preserves and compares child-node row work** ([#157](https://github.com/lessthanseventy/excessibility/issues/157)). `Excessibility.QueryPlan.summarize/1` now emits a bounded, deterministic, value-free `node_rows` list (one entry per plan node in depth-first order: `node`, `relation`, `depth`, `estimated_rows`, plus `actual_rows`/`loops`/`rows_touched`/`estimate_error` only under EXPLAIN ANALYZE). `rows_touched` = `actual_rows × loops`, so a large child scan looping beneath a one-row root is represented numerically rather than discarded. `Excessibility.DigestCompare` now compares plan row work **even when the structural fingerprint is unchanged** — a plan whose shape is stable but whose actual rows jump from 1 to 10,000 now produces a plan delta instead of `{"plans": []}`. Structural plan changes (`structural_change: true`, differing node tree) and numeric row deltas (root `estimated_rows_delta`/`actual_rows_delta` and per-node `node_deltas`) are reported separately.
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Add to `mix.exs`:
 ```elixir
 def deps do
   [
-    {:excessibility, "~> 0.18", only: [:dev, :test]}
+    {:excessibility, "~> 0.19", only: [:dev, :test]}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Excessibility.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/lessthanseventy/excessibility"
-  @version "0.18.1"
+  @version "0.19.0"
 
   def project do
     [


### PR DESCRIPTION
## Summary
Closes #168 — release prep only; **tag creation and Hex publish are intentionally left to a maintainer**.

The version-tag workflow reported success whenever `v$VERSION` already existed, without verifying the existing tag pointed at the release commit. Source could stay on an already-published version (`0.18.1`) while `main` accumulated the entire runtime-evidence feature line — a green release-consistency check while consumers cannot install the current code under the declared version.

## Changes
**Release prep**
- Bump `@version` to **0.19.0** — the documented breaking pre-1.0 Mix-task rename (`mix excessibility.compare` → `excessibility.snapshot.compare`) requires a minor bump — and the README dependency example to `~> 0.19`.
- Date the current Unreleased changelog entries as `## [0.19.0] - 2026-08-10` and open a fresh empty `## [Unreleased]`. Structured as a heading rename so that, when this merges after #169/#170, every entry under the old `[Unreleased]` (including #166/#167) is captured in `0.19.0` automatically.

**Workflow hardening**
- Peel an existing `v$VERSION` tag to the commit it targets and **fail the job** when it does not match the release commit, instead of treating existence alone as success. An idempotent re-run where the tag already targets the release commit remains a clean no-op.

## Notes for the releaser
- The existing `v0.18.1` tag and Hex package are left untouched/immutable.
- Merge this **after** #169 (#166) and #170 (#167) so `0.19.0` captures the full feature set; rebase if needed.
- Publish `0.19.0` through the normal release flow once all release blockers are resolved.

## Acceptance criteria (from #168)
- [x] Keep the existing `v0.18.1` tag and package immutable.
- [x] Assign the current feature line a new version (`0.19.0`).
- [x] Move the current Unreleased entries into a dated release section.
- [x] Make the workflow fail when an existing `v$VERSION` tag does not peel to the intended release commit.
- [ ] Publish the new version through the normal release workflow (left to maintainer — prep only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)