### PR TITLE
test: fix flaky ScannerTest global-env race

### DIFF
--- a/test/scanner_test.exs
+++ b/test/scanner_test.exs
@@ -1,5 +1,14 @@
 defmodule Excessibility.ScannerTest do
-  use ExUnit.Case, async: true
+  # NOT async: several tests override global `Application` env keys
+  # (`:playwright_path`, `:node_modules_path`) that `Excessibility.Scanner`
+  # reads at scan time. Two tests set contradictory values — one a valid path
+  # expecting `{:ok, ...}`, another `/nonexistent/...` expecting a
+  # `{:playwright_error, ...}` — so running them concurrently let one test's env
+  # (or its `on_exit` cleanup) leak into another's scan, an intermittent
+  # left/right mismatch. Serial execution keeps each override isolated to its
+  # own test. The scans are external Playwright subprocesses, so losing
+  # ExUnit-level parallelism costs almost nothing here.
+  use ExUnit.Case, async: false
 
   alias Excessibility.Scanner
 


### PR DESCRIPTION
## Summary
Fixes an intermittent full-suite failure. `Excessibility.ScannerTest` ran `async: true`, but several of its tests override the **global** `Application` env keys that `Excessibility.Scanner` reads at scan time (`playwright_env/0` → `Application.get_env(:excessibility, :playwright_path | :node_modules_path)`).

Two pairs of tests set **contradictory** values:
- `honors the :playwright_path config override` sets a valid bundled path and expects `{:ok, _}`.
- `reports an actionable error when :playwright_path is invalid` sets `/nonexistent/playwright` and expects `{:error, {:playwright_error, msg}}`.
- (same for `:node_modules_path`.)

Because tests in an async module run concurrently, one test's env write — or its `on_exit` cleanup — could leak into another test's scan, flipping `{:ok}` ↔ `{:error}` and producing an intermittent left/right assertion mismatch.

## Fix
Mark the module `async: false`. ExUnit only parallelizes async modules, so its tests now run serially and each override stays isolated to its own test. This module is the only reader of those env keys, so serial execution fully closes the race — it's a logical guarantee, not a probability.

The scans are external Playwright subprocesses (baseline showed ~35% CPU), so losing ExUnit-level parallelism costs ~4.5s on this file (13.8s → 18.4s) and nothing in correctness.

## Verification
- Root cause confirmed by code (`scanner.ex:288` reads the keys from global `Application` env).
- Stable across **8** consecutive `--repeat-until-failure` runs (22 tests, 0 failures each) after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)